### PR TITLE
feat: implement KYC verification gates for free plan users

### DIFF
--- a/app/(root)/give-credit/page.tsx
+++ b/app/(root)/give-credit/page.tsx
@@ -1,583 +1,90 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { ProfileSelector } from '@/components/shared/profile-selector';
+import { LoanForm } from '@/components/shared/loan-form';
+import { SuccessState } from '@/components/shared/success-state';
+import { useLoanForm } from '@/hooks/use-loan-form';
+import { useUser } from '@/contexts/UserContext';
+
 import {
-  Box,
-  Typography,
-  TextField,
-  Button,
-  Grid,
-  Radio,
-  RadioGroup,
-  FormControlLabel,
-  Select,
-  MenuItem,
-} from '@mui/material';
-import { styled } from '@mui/material/styles';
-import GiveCreditAppBar from '../../../components/GiveCreditAppBar';
-import NavBar from '../../../components/NavBar';
-import Image from 'next/image';
-import { motion, AnimatePresence } from 'framer-motion';
-import {
-  CheckCircleIcon,
   ChartBarIcon,
   ClockIcon,
   UserGroupIcon,
-  InformationCircleIcon,
 } from '@heroicons/react/24/outline';
-import ReactConfetti from 'react-confetti';
-import { auth } from '../../lib/firebase';
+import api from '@/utils/api';
+import GiveCreditAppBar from '@/components/GiveCreditAppBar';
+import NavBar from '@/components/NavBar';
+import KYCDialog from '@/components/KYCdialog';
 
-const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-const StyledTextField = styled(TextField)({
-  '& .MuiOutlinedInput-root': {
-    borderRadius: '12px',
-    backgroundColor: '#F9F9F9',
-    '& fieldset': {
-      borderColor: '#E5E5E5',
-    },
-    '&:hover fieldset': {
-      borderColor: '#A2195E',
-    },
-    '&.Mui-focused fieldset': {
-      borderColor: '#A2195E',
-    },
-  },
-  '& .MuiInputLabel-root': {
-    color: '#666666',
-    '&.Mui-focused': {
-      color: '#A2195E',
-    },
-  },
-});
-
-interface Profile {
-  id: string;
-  name: string;
-  mobile: string;
-  image: string;
-}
-
-interface NavBarProps {
-  className?: string;
-}
-
-const GiveCreditPage = () => {
-  const [savedProfiles, setSavedProfiles] = useState<Profile[]>([]);
-  const [requestType, setRequestType] = useState('saved');
-  const [selectedProfile, setSelectedProfile] = useState<number | null>(null);
-  const [mobileNumber, setMobileNumber] = useState('');
+export default function GiveCreditPage() {
+  const router = useRouter();
+  const { userProfile } = useUser();
+  const { formData, updateFormData } = useLoanForm('give');
   const [showLoanForm, setShowLoanForm] = useState(false);
-  const [timeUnit, setTimeUnit] = useState('month');
-  const [interestRate, setInterestRate] = useState('');
-  const [paymentType, setPaymentType] = useState('onetime');
-  const [emiFrequency, setEmiFrequency] = useState('monthly');
-  const [loanAmount, setLoanAmount] = useState('');
-  const [loanTerm, setLoanTerm] = useState('');
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
-  const [selectedLender, setSelectedLender] = useState('ABC Finance');
+  const [showKYCDialog, setShowKYCDialog] = useState(false);
   const [selectedProtectionPlan, setSelectedProtectionPlan] = useState('free');
-  const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [warningMessage, setWarningMessage] = useState<string | null>(null);
-  const [isSuccess, setIsSuccess] = useState(false);
 
-  useEffect(() => {
-    const profiles = localStorage.getItem('savedProfiles');
-    if (profiles) {
-      const parsedProfiles = JSON.parse(profiles);
-      // Ensure each profile has an image, if not set a default one
-      const profilesWithImages = parsedProfiles.map((profile: any) => ({
-        ...profile,
-        image: profile.image || '/images/saved-profiles.svg',
-      }));
-      setSavedProfiles(profilesWithImages);
-    }
-  }, []);
-
-  useEffect(() => {
-    setWindowSize({
-      width: window.innerWidth,
-      height: window.innerHeight,
-    });
-  }, []);
-
-  const calculateEMI = () => {
-    if (!loanAmount || !interestRate || !loanTerm) return 0;
-
-    const principal = parseFloat(loanAmount);
-    const ratePerPeriod =
-      parseFloat(interestRate) / 100 / (emiFrequency === 'daily' ? 365 : 12);
-    let numberOfPayments: number;
-
-    if (timeUnit === 'year') {
-      numberOfPayments =
-        emiFrequency === 'daily'
-          ? 365 * parseFloat(loanTerm)
-          : 12 * parseFloat(loanTerm);
-    } else if (timeUnit === 'month') {
-      numberOfPayments =
-        emiFrequency === 'daily'
-          ? 30 * parseFloat(loanTerm)
-          : parseFloat(loanTerm);
-    } else {
-      // days
-      numberOfPayments =
-        emiFrequency === 'daily'
-          ? parseFloat(loanTerm)
-          : parseFloat(loanTerm) / 30;
+  const handleSubmit = async () => {
+    if (userProfile?.plan === 'FREE' || !userProfile?.credit_score_enabled) {
+      setShowKYCDialog(true);
+      return;
     }
 
-    const emi =
-      (principal *
-        ratePerPeriod *
-        Math.pow(1 + ratePerPeriod, numberOfPayments)) /
-      (Math.pow(1 + ratePerPeriod, numberOfPayments) - 1);
-
-    return isNaN(emi) ? 0 : emi;
-  };
-
-  const emiAmount = calculateEMI();
-
-  const handleRequestTypeChange = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setRequestType(event.target.value);
-    setSelectedProfile(null);
-    setMobileNumber('');
-  };
-
-  const handleProfileSelect = (profileId: number) => {
-    setSelectedProfile(profileId);
-  };
-
-  const handleContinue = () => {
-    if (requestType === 'saved' && selectedProfile) {
-      setShowLoanForm(true);
-    } else if (requestType === 'new' && mobileNumber.length === 10) {
-      setShowLoanForm(true);
-    }
-  };
-
-  const handleProtectionPlanSelect = (plan: string) => {
-    setSelectedProtectionPlan(plan);
-    handleFinalSubmit();
-  };
-
-  const handleSubmit = (event: React.FormEvent) => {
-    event.preventDefault();
     setIsSubmitting(true);
-  };
-
-  const handleFinalSubmit = () => {
-    // Handle loan request submission logic here
-    const submissionData = {
-      loanAmount,
-      interestRate,
-      paymentType,
-      emiFrequency,
-      loanTerm,
-      timeUnit,
-      selectedLender,
-      protectionPlan: selectedProtectionPlan,
-    };
-    console.log('Submitting loan request:', submissionData);
-    setShowSuccessMessage(true);
-    setIsSubmitting(false);
-  };
-
-  const handleMobileNumberChange = async (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const cleanNumber = e.target.value.replace(/[^\d]/g, '').slice(0, 10);
-    setMobileNumber(cleanNumber);
-    setWarningMessage(null);
-    setIsSuccess(false);
-
-    if (cleanNumber.length === 10) {
-      try {
-        const user = auth.currentUser;
-        if (!user) {
-          console.error('User not authenticated');
-          return;
-        }
-
-        const idToken = await user.getIdToken(true);
-        const formattedNumber = `+91${cleanNumber}`;
-
-        const apiUrl = `${baseURL}/search/mobile/${formattedNumber}`;
-        console.log('Calling API endpoint:', apiUrl);
-
-        const response = await fetch(apiUrl, {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${idToken}`,
-            'Content-Type': 'application/json',
-          },
-        });
-
-        if (!response.ok) {
-          if (response.status === 404) {
-            setWarningMessage(
-              'The person you want to give credit to is not currently onboarded in Credmate. We will reach out to them through WhatsApp, SMS, and call to let them know about your credit offer.'
-            );
-            setIsSuccess(false);
-          } else {
-            throw new Error(`HTTP error! status: ${response.status}`);
-          }
-        } else {
-          const data = await response.json();
-          if (data.name) {
-            setWarningMessage(`You are offering credit to ${data.name}`);
-            setIsSuccess(true);
-          }
-        }
-      } catch (error) {
-        console.error('Error fetching data:', error);
-        setIsSuccess(false);
-      }
+    try {
+      await api.post('/credit/offer', {
+        loanAmount: Number(formData.loanAmount),
+        interestRate: Number(formData.interestRate),
+        paymentType: formData.paymentType,
+        emiFrequency: formData.emiFrequency,
+        loanTerm: Number(formData.loanTerm),
+        timeUnit: formData.timeUnit,
+        protectionPlan: selectedProtectionPlan,
+      });
+      setShowSuccessMessage(true);
+    } catch (error) {
+      console.error('Error submitting offer:', error);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   if (showSuccessMessage) {
     return (
-      <div className='flex flex-col h-screen bg-gradient-to-br from-white via-pink-50 to-purple-50'>
-        <GiveCreditAppBar
-          loanAmount={Number(loanAmount) || 0}
-          onProtectionPlanSelect={handleProtectionPlanSelect}
-          isSubmitting={isSubmitting}
-        />
-        <ReactConfetti
-          width={windowSize.width}
-          height={windowSize.height}
-          recycle={false}
-          numberOfPieces={200}
-          gravity={0.2}
-        />
-        <main className='flex-1 overflow-y-auto pt-14'>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className='px-6 pt-10 pb-24 flex flex-col items-center justify-center min-h-full'
-          >
-            <motion.div
-              initial={{ scale: 0 }}
-              animate={{ scale: 1 }}
-              transition={{ type: 'spring', stiffness: 200, damping: 15 }}
-              className='w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mb-6'
-            >
-              <CheckCircleIcon className='w-12 h-12 text-green-600' />
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2 }}
-              className='text-center'
-            >
-              <h2 className='text-3xl font-bold text-gray-800 mb-4'>
-                Credit Offer Submitted Successfully! 🎉
-              </h2>
-              <p className='text-lg text-gray-600 max-w-md mb-8'>
-                Your P2P lending offer has been sent to the borrower.
-              </p>
-            </motion.div>
-
-            <div className='grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-4xl'>
-              {[
-                {
-                  icon: <UserGroupIcon className='w-8 h-8' />,
-                  title: 'Matching Process',
-                  description: "We're notifying the borrower of your offer",
-                },
-                {
-                  icon: <ClockIcon className='w-8 h-8' />,
-                  title: 'Quick Response',
-                  description: 'Expect responses within 24-48 hours',
-                },
-                {
-                  icon: <ChartBarIcon className='w-8 h-8' />,
-                  title: 'Next Steps',
-                  description: 'Contract review and digital signing process',
-                },
-              ].map((item, index) => (
-                <motion.div
-                  key={index}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.4 + index * 0.1 }}
-                  className='bg-white rounded-xl p-6 shadow-lg'
-                >
-                  <div className='w-12 h-12 bg-pink-100 rounded-full flex items-center justify-center mb-4'>
-                    {item.icon}
-                  </div>
-                  <h3 className='text-lg font-semibold mb-2'>{item.title}</h3>
-                  <p className='text-gray-600'>{item.description}</p>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </main>
-        <NavBar />
-      </div>
-    );
-  }
-
-  if (!showLoanForm) {
-    return (
       <div className='flex flex-col min-h-screen bg-gradient-to-br from-white via-pink-50 to-purple-50'>
         <GiveCreditAppBar
-          loanAmount={Number(loanAmount) || 0}
-          onProtectionPlanSelect={handleProtectionPlanSelect}
+          loanAmount={Number(formData.loanAmount)}
           isSubmitting={isSubmitting}
+          onProtectionPlanSelect={setSelectedProtectionPlan}
         />
-        <main className='flex-1 overflow-y-auto pt-20 pb-24 px-4'>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className='max-w-lg mx-auto'
-          >
-            <div className='bg-white rounded-3xl shadow-lg p-6 mb-6'>
-              <h2 className='text-2xl font-bold text-gray-800 mb-6 text-center'>
-                Give Credit
-              </h2>
-
-              <RadioGroup
-                value={requestType}
-                onChange={handleRequestTypeChange}
-                className='mb-6'
-              >
-                <div className='grid grid-cols-2 gap-4'>
-                  <motion.div whileTap={{ scale: 0.98 }}>
-                    <FormControlLabel
-                      value='saved'
-                      control={<Radio />}
-                      label={
-                        <div className='flex flex-col items-center p-4 bg-pink-50 rounded-xl cursor-pointer transition-all hover:bg-pink-100'>
-                          <div className='w-16 h-16 rounded-full bg-pink-200 flex items-center justify-center flex-shrink-0'>
-                            <Image
-                              src='/images/savedborrowers.svg'
-                              alt='Saved Profiles'
-                              width={41}
-                              height={41}
-                              className='mb-2 mt-2'
-                            />
-                          </div>
-                          <span className='font-medium text-gray-800'>
-                            Saved Borrowers
-                          </span>
-                        </div>
-                      }
-                      className='m-0 w-full'
-                    />
-                  </motion.div>
-
-                  <motion.div whileTap={{ scale: 0.98 }}>
-                    <FormControlLabel
-                      value='new'
-                      control={<Radio />}
-                      label={
-                        <div className='flex flex-col items-center p-4 bg-pink-50 rounded-xl cursor-pointer transition-all hover:bg-pink-100'>
-                          <div className='w-16 h-16 rounded-full bg-pink-200 flex items-center justify-center flex-shrink-0'>
-                            <Image
-                              src='/images/newborrower.svg'
-                              alt='New Profile'
-                              width={45}
-                              height={45}
-                              className='mb-2 mt-1'
-                            />
-                          </div>
-                          <span className='font-medium text-gray-800'>
-                            New Borrower
-                          </span>
-                        </div>
-                      }
-                      className='m-0 w-full'
-                    />
-                  </motion.div>
-                </div>
-              </RadioGroup>
-
-              <AnimatePresence mode='wait'>
-                {requestType === 'saved' ? (
-                  <motion.div
-                    key='saved'
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                  >
-                    <div className='space-y-4'>
-                      {savedProfiles.map((profile) => (
-                        <motion.div
-                          key={profile.id}
-                          whileHover={{ scale: 1.02 }}
-                          whileTap={{ scale: 0.98 }}
-                          onClick={() =>
-                            handleProfileSelect(Number(profile.id))
-                          }
-                          className={`p-4 rounded-xl border-2 transition-all cursor-pointer ${
-                            selectedProfile === Number(profile.id)
-                              ? 'border-pink-500 bg-pink-50'
-                              : 'border-gray-200 hover:border-pink-200'
-                          }`}
-                        >
-                          <div className='flex items-center space-x-4'>
-                            <div className='w-12 h-12 rounded-full overflow-hidden bg-gray-100'>
-                              <Image
-                                src={profile.image}
-                                alt={profile.name}
-                                width={48}
-                                height={48}
-                                className='object-cover'
-                              />
-                            </div>
-                            <div>
-                              <h3 className='font-semibold text-gray-800'>
-                                {profile.name}
-                              </h3>
-                              <p className='text-sm text-gray-500'>
-                                {profile.mobile}
-                              </p>
-                            </div>
-                            <div className='ml-auto'>
-                              <div className='text-sm text-green-600 font-medium'>
-                                Credit Score: 750
-                              </div>
-                              <div className='text-xs text-gray-500'>
-                                Very Good
-                              </div>
-                            </div>
-                          </div>
-                        </motion.div>
-                      ))}
-                    </div>
-                  </motion.div>
-                ) : (
-                  <motion.div
-                    key='new'
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                  >
-                    <StyledTextField
-                      fullWidth
-                      label="Borrower's Mobile Number"
-                      variant='outlined'
-                      value={mobileNumber}
-                      onChange={handleMobileNumberChange}
-                      placeholder='Enter 10-digit number'
-                      inputProps={{
-                        maxLength: 10,
-                        pattern: '[0-9]*',
-                      }}
-                      className='mb-4'
-                    />
-                    {warningMessage && (
-                      <motion.div
-                        initial={{ opacity: 0, y: -10 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        className={`flex items-center p-4 mb-4 rounded-lg ${
-                          isSuccess
-                            ? 'bg-green-50 text-green-800'
-                            : 'bg-yellow-50 text-yellow-800'
-                        }`}
-                      >
-                        {isSuccess ? (
-                          <CheckCircleIcon className='w-5 h-5 mr-2 text-green-600' />
-                        ) : (
-                          <InformationCircleIcon className='w-5 h-5 mr-2 text-yellow-600' />
-                        )}
-                        <span className='text-sm'>{warningMessage}</span>
-                      </motion.div>
-                    )}
-                    {!warningMessage && (
-                      <div className='bg-blue-50 rounded-xl p-4 mb-4'>
-                        <div className='flex items-start space-x-3'>
-                          <div className='p-2 bg-blue-100 rounded-lg'>
-                            <Image
-                              src='/images/info-icon.svg'
-                              alt='Info'
-                              width={20}
-                              height={20}
-                            />
-                          </div>
-                          <div>
-                            <h4 className='font-medium text-blue-800'>
-                              First time lending?
-                            </h4>
-                            <p className='text-sm text-blue-600'>
-                              We'll verify the borrower's details before
-                              proceeding
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-                  </motion.div>
-                )}
-              </AnimatePresence>
-
-              <motion.button
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-                onClick={handleContinue}
-                disabled={
-                  !(requestType === 'saved' && selectedProfile) &&
-                  !(requestType === 'new' && mobileNumber.length === 10)
-                }
-                className={`w-full py-4 rounded-xl font-semibold text-white transition-all
-                  ${
-                    (requestType === 'saved' && selectedProfile) ||
-                    (requestType === 'new' && mobileNumber.length === 10)
-                      ? 'bg-pink-600 hover:bg-pink-700'
-                      : 'bg-gray-300 cursor-not-allowed'
-                  }`}
-              >
-                Continue
-              </motion.button>
-            </div>
-
-            <div className='bg-gradient-to-r from-pink-50 to-purple-50 rounded-3xl p-6'>
-              <h3 className='font-semibold text-gray-800 mb-4'>
-                Benefits of P2P Lending
-              </h3>
-              <div className='space-y-4'>
-                {[
-                  {
-                    title: 'Higher Returns',
-                    desc: 'Earn better interest rates than traditional investments',
-                  },
-                  {
-                    title: 'Flexible Terms',
-                    desc: 'Choose your own lending terms and conditions',
-                  },
-                  {
-                    title: 'Secure Platform',
-                    desc: 'End-to-end encrypted transaction processing',
-                  },
-                ].map((item, index) => (
-                  <motion.div
-                    key={index}
-                    initial={{ opacity: 0, x: -20 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    transition={{ delay: index * 0.1 }}
-                    className='flex items-start space-x-3'
-                  >
-                    <div className='w-6 h-6 rounded-full bg-pink-200 flex items-center justify-center flex-shrink-0'>
-                      <span className='text-pink-700 text-sm'>✓</span>
-                    </div>
-                    <div>
-                      <h4 className='font-medium text-gray-800'>
-                        {item.title}
-                      </h4>
-                      <p className='text-sm text-gray-600'>{item.desc}</p>
-                    </div>
-                  </motion.div>
-                ))}
-              </div>
-            </div>
-          </motion.div>
+        <main className='flex-1 overflow-y-auto'>
+          <SuccessState
+            title='Credit Offer Submitted Successfully! 🎉'
+            description='Your P2P lending offer has been sent to the borrower.'
+            steps={[
+              {
+                icon: <UserGroupIcon className='w-8 h-8' />,
+                title: 'Matching Process',
+                description: "We're notifying the borrower of your offer",
+              },
+              {
+                icon: <ClockIcon className='w-8 h-8' />,
+                title: 'Quick Response',
+                description: 'Expect responses within 24-48 hours',
+              },
+              {
+                icon: <ChartBarIcon className='w-8 h-8' />,
+                title: 'Next Steps',
+                description: 'Contract review and digital signing process',
+              },
+            ]}
+            onDashboardClick={() => router.push('/dashboard')}
+          />
         </main>
         <NavBar />
       </div>
@@ -587,309 +94,38 @@ const GiveCreditPage = () => {
   return (
     <div className='flex flex-col min-h-screen bg-gradient-to-br from-white via-pink-50 to-purple-50'>
       <GiveCreditAppBar
-        loanAmount={Number(loanAmount) || 0}
-        onProtectionPlanSelect={handleProtectionPlanSelect}
+        loanAmount={Number(formData.loanAmount)}
         isSubmitting={isSubmitting}
+        onProtectionPlanSelect={setSelectedProtectionPlan}
       />
-      <main className='flex-1 overflow-y-auto pt-20 pb-24 px-4'>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className='max-w-lg mx-auto'
-        >
-          <form onSubmit={handleSubmit} className='space-y-6'>
-            <div className='bg-white rounded-3xl shadow-lg p-6'>
-              <h2 className='text-2xl font-bold text-gray-800 mb-6'>
-                Lending Details
-              </h2>
-
-              <div className='space-y-6'>
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-2'>
-                    Amount to Lend
-                  </label>
-                  <div className='relative'>
-                    <div className='absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none'>
-                      <span className='text-gray-500'>₹</span>
-                    </div>
-                    <StyledTextField
-                      fullWidth
-                      type='number'
-                      value={loanAmount}
-                      onChange={(e) => setLoanAmount(e.target.value)}
-                      placeholder='Enter amount'
-                      InputProps={{
-                        startAdornment: (
-                          <span className='text-gray-500 mr-2'>₹</span>
-                        ),
-                      }}
-                      className='mb-1'
-                    />
-                  </div>
-                  <p className='text-sm text-gray-500 mt-1'>
-                    Min: ₹1,000 | Max: ₹10,00,000
-                  </p>
-                </div>
-
-                <div className='grid grid-cols-2 gap-4'>
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Lending Term
-                    </label>
-                    <StyledTextField
-                      fullWidth
-                      type='number'
-                      value={loanTerm}
-                      onChange={(e) => setLoanTerm(e.target.value)}
-                      placeholder='Duration'
-                    />
-                  </div>
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Time Unit
-                    </label>
-                    <Select
-                      value={timeUnit}
-                      onChange={(e) => setTimeUnit(e.target.value)}
-                      className='w-full rounded-xl'
-                      sx={{
-                        borderRadius: '12px',
-                        '& .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#E5E5E5',
-                        },
-                        '&:hover .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#A2195E',
-                        },
-                        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#A2195E',
-                        },
-                      }}
-                    >
-                      <MenuItem value='month'>Months</MenuItem>
-                      <MenuItem value='year'>Years</MenuItem>
-                      <MenuItem value='day'>Days</MenuItem>
-                    </Select>
-                  </div>
-                </div>
-
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-2'>
-                    Expected Interest Rate (% per annum)
-                  </label>
-                  <StyledTextField
-                    fullWidth
-                    type='number'
-                    value={interestRate}
-                    onChange={(e) => setInterestRate(e.target.value)}
-                    placeholder='Enter interest rate'
-                    InputProps={{
-                      endAdornment: <span className='text-gray-500'>%</span>,
-                    }}
-                  />
-                </div>
-
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-4'>
-                    Preferred Payment Type
-                  </label>
-                  <div className='grid grid-cols-2 gap-4'>
-                    <motion.div whileTap={{ scale: 0.98 }}>
-                      <FormControlLabel
-                        value='onetime'
-                        control={
-                          <Radio
-                            checked={paymentType === 'onetime'}
-                            onChange={(e) => setPaymentType(e.target.value)}
-                          />
-                        }
-                        label={
-                          <div
-                            className={`flex flex-col items-center p-4 rounded-xl cursor-pointer transition-all
-                            ${paymentType === 'onetime' ? 'bg-pink-50' : 'bg-gray-50 hover:bg-gray-100'}`}
-                          >
-                            <Image
-                              src='/images/onetime-payment.svg'
-                              alt='One-time Payment'
-                              width={32}
-                              height={32}
-                              className='mb-2'
-                            />
-                            <span className='font-medium text-sm text-gray-800'>
-                              One-time Payment
-                            </span>
-                          </div>
-                        }
-                        className='m-0 w-full'
-                      />
-                    </motion.div>
-
-                    <motion.div whileTap={{ scale: 0.98 }}>
-                      <FormControlLabel
-                        value='emi'
-                        control={
-                          <Radio
-                            checked={paymentType === 'emi'}
-                            onChange={(e) => setPaymentType(e.target.value)}
-                          />
-                        }
-                        label={
-                          <div
-                            className={`flex flex-col items-center p-4 rounded-xl cursor-pointer transition-all
-                            ${paymentType === 'emi' ? 'bg-pink-50' : 'bg-gray-50 hover:bg-gray-100'}`}
-                          >
-                            <Image
-                              src='/images/emi-payment.svg'
-                              alt='EMI'
-                              width={32}
-                              height={32}
-                              className='mb-2'
-                            />
-                            <span className='font-medium text-sm text-gray-800'>
-                              EMI
-                            </span>
-                          </div>
-                        }
-                        className='m-0 w-full'
-                      />
-                    </motion.div>
-                  </div>
-                </div>
-
-                {paymentType === 'emi' && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                  >
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      EMI Frequency
-                    </label>
-                    <Select
-                      value={emiFrequency}
-                      onChange={(e) =>
-                        setEmiFrequency(e.target.value as string)
-                      }
-                      className='w-full rounded-xl'
-                      sx={{
-                        borderRadius: '12px',
-                        '& .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#E5E5E5',
-                        },
-                        '&:hover .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#A2195E',
-                        },
-                        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#A2195E',
-                        },
-                      }}
-                    >
-                      <MenuItem value='daily'>Daily</MenuItem>
-                      <MenuItem value='weekly'>Weekly</MenuItem>
-                      <MenuItem value='monthly'>Monthly</MenuItem>
-                    </Select>
-                  </motion.div>
-                )}
-
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-2'>
-                    Protection Plan
-                  </label>
-                  <div className='space-y-3'>
-                    {[
-                      {
-                        id: 'free',
-                        name: 'Basic',
-                        price: 'Free',
-                        coverage: 'Basic fraud protection',
-                      },
-                      {
-                        id: 'standard',
-                        name: 'Standard',
-                        price: '₹499',
-                        coverage: 'Up to 50% coverage',
-                      },
-                      {
-                        id: 'premium',
-                        name: 'Premium',
-                        price: '₹999',
-                        coverage: 'Up to 100% coverage',
-                      },
-                    ].map((plan) => (
-                      <motion.div
-                        key={plan.id}
-                        whileHover={{ scale: 1.02 }}
-                        whileTap={{ scale: 0.98 }}
-                        onClick={() => setSelectedProtectionPlan(plan.id)}
-                        className={`p-4 rounded-xl border-2 cursor-pointer transition-all ${
-                          selectedProtectionPlan === plan.id
-                            ? 'bg-pink-500 bg-pink-50'
-                            : 'border-gray-200 hover:border-pink-200'
-                        }`}
-                      >
-                        <div className='flex items-center justify-between'>
-                          <div>
-                            <h4 className='font-semibold text-gray-800'>
-                              {plan.name}
-                            </h4>
-                            <p className='text-sm text-gray-600'>
-                              {plan.coverage}
-                            </p>
-                          </div>
-                          <div className='text-right'>
-                            <p className='font-bold text-pink-600'>
-                              {plan.price}
-                            </p>
-                          </div>
-                        </div>
-                      </motion.div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* EMI Calculator Result */}
-            {paymentType === 'emi' && emiAmount > 0 && (
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                className='bg-gradient-to-r from-pink-600 to-purple-600 rounded-3xl p-6 text-white'
-              >
-                <h3 className='text-lg font-semibold mb-2'>EMI Calculator</h3>
-                <div className='flex justify-between items-center'>
-                  <div>
-                    <p className='text-sm opacity-90'>Expected EMI Amount</p>
-                    <p className='text-2xl font-bold'>
-                      ₹{emiAmount.toFixed(2)}
-                    </p>
-                  </div>
-                  <div className='w-12 h-12 bg-white/20 rounded-full flex items-center justify-center'>
-                    <Image
-                      src='/images/calculator.svg'
-                      alt='Calculator'
-                      width={24}
-                      height={24}
-                    />
-                  </div>
-                </div>
-              </motion.div>
-            )}
-
-            {/* Submit Button */}
-            <motion.button
-              type='submit'
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
-              className='w-full py-4 bg-pink-600 text-white rounded-xl font-semibold hover:bg-pink-700 transition-colors'
-            >
-              Submit Offer
-            </motion.button>
-          </form>
-        </motion.div>
+      <main className='flex-1 px-4 pt-20 pb-24 overflow-y-auto'>
+        {!showLoanForm ? (
+          <ProfileSelector
+            type='borrower'
+            savedProfiles={[]}
+            onProfileSelect={(profile) => {
+              if (profile) setShowLoanForm(true);
+            }}
+            onMobileNumberSubmit={(mobile) => {
+              if (mobile.length === 10) setShowLoanForm(true);
+            }}
+          />
+        ) : (
+          <LoanForm
+            formData={formData}
+            onChange={updateFormData}
+            onSubmit={handleSubmit}
+            submitButtonText='Submit Offer'
+          />
+        )}
       </main>
       <NavBar />
+      <KYCDialog
+        isOpen={showKYCDialog}
+        onClose={() => setShowKYCDialog(false)}
+        title='KYC Required for Credit Offer'
+        description='To submit credit offers, you need to complete the KYC process first.'
+      />
     </div>
   );
-};
-
-export default GiveCreditPage;
+}

--- a/app/(root)/report-borrower/page.tsx
+++ b/app/(root)/report-borrower/page.tsx
@@ -2,270 +2,105 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  Button,
-  TextField,
-  Checkbox,
-  FormControlLabel,
-  Typography,
-  Box,
-  Container,
-  Radio,
-  RadioGroup,
-  Modal,
-  IconButton,
-} from '@mui/material';
-import {
-  ChevronLeft,
-  Phone,
-  Calendar,
-  IndianRupee,
-  AlertCircle,
-  Shield,
-  PhoneCall,
-  Info,
-  X,
-  Users,
-} from 'lucide-react';
+import { Container } from '@mui/material';
 import { motion } from 'framer-motion';
-import Image from 'next/image';
-import { auth } from '../../../lib/firebase';
+import { AlertCircle } from 'lucide-react';
+import { ReportBorrowerAppBar } from '@/components/report-borrower-app-bar';
+import { ReportTypeSelector } from '@/components/shared/report-type-selector';
+import { ReportForm } from '@/components/shared/report-form';
+import { InfoModal } from '@/components/shared/info-modal';
+import { ReportModalContent } from '@/components/shared/report-modal-content';
+import { RecoveryModalContent } from '@/components/shared/recovery-modal-content';
+import { useLoanForm } from '@/hooks/use-loan-form';
+import { useUser } from '@/contexts/UserContext';
+import api from '@/utils/api';
+import KYCDialog from '@/components/KYCdialog';
 
-const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-export default function ReportBorrower() {
+export default function ReportBorrowerPage() {
   const router = useRouter();
-  const [formData, setFormData] = useState({
-    borrowerPhone: '',
-    unpaidAmount: '',
-    dueDate: '',
-    consent: false,
-    reportType: 'report_only', // 'report_only', 'recovery_service'
-  });
+  const { userProfile } = useUser();
+  const { formData, updateFormData } = useLoanForm('report');
 
   const [openRecoveryModal, setOpenRecoveryModal] = useState(false);
   const [openReportModal, setOpenReportModal] = useState(false);
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
+  const [showKYCDialog, setShowKYCDialog] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // Prevent submission if there's a warning message
+    if (userProfile?.plan === 'FREE' || !userProfile?.credit_score_enabled) {
+      setShowKYCDialog(true);
+      return;
+    }
+
     if (warningMessage) {
       console.log('Form submission blocked due to warning:', warningMessage);
       return;
     }
 
     try {
-      console.log('Form submitted:', formData);
-      const recoveryFee =
-        formData.reportType === 'recovery_service'
-          ? (parseFloat(formData.unpaidAmount) * 0.02).toFixed(2)
-          : 0;
-      console.log('Recovery fee:', recoveryFee);
-
-      const user = auth.currentUser;
-      if (!user) {
-        console.error('User not authenticated. Please login again.');
-        return;
-      }
-
-      const idToken = await user.getIdToken(true);
-
       const requestBody = {
         mobileNumber: `+91${formData.borrowerPhone}`,
-        unpaidAmount: parseFloat(formData.unpaidAmount),
-        dueDate: new Date(formData.dueDate).toISOString(),
+        unpaidAmount: parseFloat(formData.loanAmount),
+        dueDate: formData.dueDate
+          ? new Date(formData.dueDate).toISOString()
+          : new Date().toISOString(),
         recoveryMode: formData.reportType === 'recovery_service',
       };
 
-      alert(
-        `Making API Call to: ${baseURL}/borrower/report_borrower\n\nHeaders:\n${JSON.stringify(
-          {
-            Authorization: 'Bearer ' + idToken,
-            'Content-Type': 'application/json',
-          },
-          null,
-          2
-        )}\n\nRequest Body:\n${JSON.stringify(requestBody, null, 2)}`
-      );
-
-      const response = await fetch(`${baseURL}/borrower/report_borrower`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestBody),
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        alert(
-          `API Error!\nStatus: ${response.status}\nResponse:\n${errorText}`
-        );
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      alert(`API Response:\n${JSON.stringify(data, null, 2)}`);
-      console.log('Report submitted successfully:', data);
-
-      // Redirect to thank you page
+      await api.post('/borrower/report_borrower', requestBody);
       router.push('/report-success');
     } catch (error) {
       console.error('Error submitting form:', error);
     }
   };
 
-  const handleInputChange =
-    (field: string) => async (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (field === 'borrowerPhone') {
-        // Only allow digits and limit to 10 characters
-        const cleanNumber = e.target.value.replace(/[^\d]/g, '').slice(0, 10);
-        setFormData({ ...formData, [field]: cleanNumber });
+  const handleInputChange = async (field: string, value: string | boolean) => {
+    updateFormData({ [field]: value });
 
-        // Make API call when 10 digits are entered
-        if (cleanNumber.length === 10) {
-          try {
-            const user = auth.currentUser;
-            if (!user) {
-              console.error('User not authenticated. Please login again.');
-              return;
-            }
+    if (field === 'borrowerPhone' && typeof value === 'string') {
+      const cleanNumber = value.replace(/[^\d]/g, '').slice(0, 10);
 
-            console.log('Making API call for number:', cleanNumber);
-            const idToken = await user.getIdToken(true);
-            const formattedNumber = `+91${cleanNumber}`;
-
-            const apiUrl = `${baseURL}/search/mobile/${formattedNumber}`;
-            alert(
-              `Making API Call to: ${apiUrl}\n\nHeaders:\n${JSON.stringify(
-                {
-                  Authorization: 'Bearer ' + idToken,
-                  'Content-Type': 'application/json',
-                },
-                null,
-                2
-              )}`
+      if (cleanNumber.length === 10) {
+        try {
+          const { data } = await api.get(`/search/mobile/+91${cleanNumber}`);
+          if (data.name) {
+            setWarningMessage(
+              `The phone number belongs to ${data.name} who is already a part of the Credmate community.`
             );
-
-            const response = await fetch(apiUrl, {
-              method: 'GET',
-              headers: {
-                Authorization: `Bearer ${idToken}`,
-                'Content-Type': 'application/json',
-              },
-            });
-
-            if (!response.ok) {
-              const errorText = await response.text();
-              alert(
-                `API Error!\nStatus: ${response.status}\nResponse:\n${errorText}`
-              );
-              console.error('API Error:', {
-                status: response.status,
-                statusText: response.statusText,
-                url: apiUrl,
-              });
-              setWarningMessage(null);
-              throw new Error(`HTTP error! status: ${response.status}`);
-            }
-
-            const data = await response.json();
-            alert(`API Response:\n${JSON.stringify(data, null, 2)}`);
-
-            // Add detailed logging to debug
-            console.log('Checking conditions:', {
-              responseOk: response.ok,
-              hasName: !!data.name,
-              name: data.name,
-              fullData: data,
-            });
-
-            // Adjusted condition to check direct properties
-            if (response.ok && data.name) {
-              console.log('Setting warning message for name:', data.name);
-              setWarningMessage(
-                `The phone number belongs to ${data.name} who is already a part of the Credmate community. Only those who are not part of Credmate community can be reported.`
-              );
-            } else {
-              console.log('Clearing warning message');
-              setWarningMessage(null);
-            }
-          } catch (error) {
-            console.error('Error fetching data:', error);
+          }
+        } catch (error: any) {
+          if (error.response?.status === 404) {
+            setWarningMessage(
+              'The person is not currently onboarded in Credmate. We will reach out to them.'
+            );
           }
         }
-      } else {
-        setFormData({ ...formData, [field]: e.target.value });
       }
-    };
-
-  const calculateRecoveryFee = () => {
-    if (!formData.unpaidAmount) return '0';
-    return (parseFloat(formData.unpaidAmount) * 0.02).toFixed(2);
+    }
   };
 
   return (
-    <div className='h-screen flex flex-col bg-gradient-to-br from-white via-pink-50 to-purple-50'>
-      {/* Header - Fixed */}
-      <div className='bg-gradient-to-r from-[#A2195E] to-[#8B1550] p-4'>
-        <div className='flex items-center gap-3'>
-          <button
-            onClick={() => router.push('/')}
-            className='text-white hover:opacity-80 transition-opacity'
-          >
-            <ChevronLeft className='w-6 h-6' />
-          </button>
-          <h1 className='text-xl font-semibold text-white'>Report Borrower</h1>
-        </div>
+    <div className='flex flex-col h-screen bg-gradient-to-br from-white via-pink-50 to-purple-50'>
+      <ReportBorrowerAppBar />
 
-        {/* Header Content */}
-        <div className='mt-6 px-4 text-white'>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2 }}
-          >
-            <div className='flex justify-between items-center'>
-              <div>
-                <h2 className='text-2xl font-bold mb-2'>Report Unpaid Loan</h2>
-                <p className='text-white/80'>
-                  Help us maintain a healthy credit ecosystem
-                </p>
-              </div>
-              <div className='relative w-20 h-20'>
-                <Image
-                  src='/images/Frame.svg'
-                  alt='Report Icon'
-                  width={80}
-                  height={80}
-                  className='brightness-0 invert opacity-90'
-                />
-              </div>
-            </div>
-          </motion.div>
-        </div>
-      </div>
-
-      {/* Scrollable Content */}
       <div className='flex-1 overflow-y-auto'>
-        <Container maxWidth='sm' className='py-6 px-4 pb-20'>
+        <Container maxWidth='sm' className='px-4 py-6 pb-20'>
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
           >
-            <div className='bg-white rounded-3xl shadow-xl p-6 relative mt-4'>
+            <div className='relative p-6 mt-4 bg-white shadow-xl rounded-3xl'>
               {/* Info Box */}
               <motion.div
-                className='bg-orange-50 rounded-2xl p-4 mb-6 border border-orange-200'
+                className='p-4 mb-6 border border-orange-200 bg-orange-50 rounded-2xl'
                 initial={{ opacity: 0, x: -20 }}
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ delay: 0.3 }}
               >
-                <div className='flex gap-3 items-start'>
+                <div className='flex items-start gap-3'>
                   <AlertCircle className='w-5 h-5 text-orange-500 flex-shrink-0 mt-0.5' />
                   <p className='text-sm text-orange-700'>
                     Please ensure all information provided is accurate. False
@@ -274,801 +109,52 @@ export default function ReportBorrower() {
                 </div>
               </motion.div>
 
-              <form onSubmit={handleSubmit} className='space-y-6'>
-                {/* Report Type Selection */}
-                <div className='space-y-4'>
-                  <Typography
-                    variant='subtitle1'
-                    className='font-semibold text-gray-700'
-                  >
-                    Choose Report Type
-                  </Typography>
-                  <RadioGroup
-                    value={formData.reportType}
-                    onChange={(e) =>
-                      setFormData({ ...formData, reportType: e.target.value })
-                    }
-                    className='space-y-3'
-                  >
-                    {/* Report Only Option */}
-                    <motion.div
-                      whileHover={{ scale: 1.01 }}
-                      whileTap={{ scale: 0.99 }}
-                      className={`relative rounded-xl border-2 transition-all cursor-pointer
-                        ${
-                          formData.reportType === 'report_only'
-                            ? 'border-[#A2195E] bg-pink-50'
-                            : 'border-gray-200 bg-white'
-                        }`}
-                    >
-                      <FormControlLabel
-                        value='report_only'
-                        control={
-                          <Radio
-                            sx={{
-                              color: '#A2195E',
-                              '&.Mui-checked': {
-                                color: '#A2195E',
-                              },
-                            }}
-                          />
-                        }
-                        label={
-                          <div className='py-2'>
-                            <div className='flex items-center gap-3'>
-                              <Shield className='w-5 h-5 text-[#A2195E]' />
-                              <span className='font-semibold text-gray-800'>
-                                Report Only
-                              </span>
-                              <IconButton
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  setOpenReportModal(true);
-                                }}
-                                size='small'
-                                sx={{ color: '#A2195E' }}
-                              >
-                                <Info className='w-4 h-4' />
-                              </IconButton>
-                            </div>
-                            <p className='text-sm text-gray-600 mt-1 ml-8'>
-                              Report defaulter to protect others. This
-                              information will be used to warn other lenders.
-                            </p>
-                            <div className='ml-8 mt-2 text-sm font-medium text-[#A2195E]'>
-                              Free
-                            </div>
-                          </div>
-                        }
-                        className='w-full m-0 p-3'
-                      />
-                    </motion.div>
+              <ReportTypeSelector
+                value={formData.reportType || 'report_only'}
+                onChange={(value: 'report_only' | 'recovery_service') =>
+                  updateFormData({ reportType: value })
+                }
+                onInfoClick={(type) => {
+                  if (type === 'report_only') setOpenReportModal(true);
+                  else setOpenRecoveryModal(true);
+                }}
+              />
 
-                    {/* Recovery Service Option */}
-                    <motion.div
-                      whileHover={{ scale: 1.01 }}
-                      whileTap={{ scale: 0.99 }}
-                      className={`relative rounded-xl border-2 transition-all cursor-pointer
-                        ${
-                          formData.reportType === 'recovery_service'
-                            ? 'border-[#A2195E] bg-pink-50'
-                            : 'border-gray-200 bg-white'
-                        }`}
-                    >
-                      <FormControlLabel
-                        value='recovery_service'
-                        control={
-                          <Radio
-                            sx={{
-                              color: '#A2195E',
-                              '&.Mui-checked': {
-                                color: '#A2195E',
-                              },
-                            }}
-                          />
-                        }
-                        label={
-                          <div className='py-2'>
-                            <div className='flex items-center gap-3'>
-                              <PhoneCall className='w-5 h-5 text-[#A2195E]' />
-                              <span className='font-semibold text-gray-800'>
-                                Assistance Service
-                              </span>
-                              <IconButton
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  setOpenRecoveryModal(true);
-                                }}
-                                size='small'
-                                sx={{ color: '#A2195E' }}
-                              >
-                                <Info className='w-4 h-4' />
-                              </IconButton>
-                            </div>
-                            <p className='text-sm text-gray-600 mt-1 ml-8'>
-                              We are here to assist you with recovering your
-                              money through our dedicated and professional
-                              recovery services.{' '}
-                            </p>
-                          </div>
-                        }
-                        className='w-full m-0 p-3'
-                      />
-                    </motion.div>
-                  </RadioGroup>
-                </div>
-
-                {/* Phone Input */}
-                <div className='relative'>
-                  <Phone className='w-5 h-5 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2' />
-                  <TextField
-                    fullWidth
-                    label="Borrower's Phone Number"
-                    variant='outlined'
-                    value={formData.borrowerPhone}
-                    onChange={handleInputChange('borrowerPhone')}
-                    type='tel'
-                    required
-                    inputProps={{
-                      pattern: '[0-9]{10}',
-                      maxLength: 10,
-                    }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': {
-                        paddingLeft: '2.5rem', // Adds space for the icon
-                        borderRadius: '12px',
-                        '&:hover fieldset': {
-                          borderColor: '#A2195E', // Hover border color
-                        },
-                        '&.Mui-focused fieldset': {
-                          borderColor: '#A2195E', // Focused border color
-                        },
-                      },
-                      '& .MuiInputLabel-root': {
-                        transform: 'translate(2.5rem, 1rem) scale(1)', // Moved further to the right
-                      },
-                      '& .MuiInputLabel-root.Mui-focused, & .MuiInputLabel-root.MuiFormLabel-filled':
-                        {
-                          transform: 'translate(1rem, -0.5rem) scale(0.75)', // Shrinks and moves up
-                        },
-                      '& .MuiInputLabel-root.Mui-focused': {
-                        color: '#A2195E', // Focused label color
-                      },
-                    }}
-                  />
-                </div>
-
-                {warningMessage && (
-                  <Box
-                    sx={{
-                      mt: 2,
-                      p: 2,
-                      bgcolor: '#FFF4E5',
-                      borderRadius: 1,
-                      border: '1px solid #FFB74D',
-                      display: 'flex',
-                      alignItems: 'flex-start',
-                      gap: 1,
-                      width: '100%', // Added full width
-                    }}
-                  >
-                    <AlertCircle size={20} className='text-orange-500 mt-0.5' />
-                    <Typography color='warning.dark' sx={{ flex: 1 }}>
-                      {warningMessage}
-                    </Typography>
-                  </Box>
-                )}
-
-                {/* Amount Input */}
-                <div className='relative'>
-                  <IndianRupee className='w-5 h-5 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2' />
-                  <TextField
-                    fullWidth
-                    label='Unpaid Amount'
-                    variant='outlined'
-                    value={formData.unpaidAmount}
-                    onChange={handleInputChange('unpaidAmount')}
-                    type='number'
-                    required
-                    inputProps={{
-                      min: 0,
-                      step: '0.01',
-                    }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': {
-                        paddingLeft: '2.5rem', // Adds space for the icon
-                        borderRadius: '12px',
-                        '&:hover fieldset': {
-                          borderColor: '#A2195E', // Hover border color
-                        },
-                        '&.Mui-focused fieldset': {
-                          borderColor: '#A2195E', // Focused border color
-                        },
-                      },
-                      '& .MuiInputLabel-root': {
-                        transform: 'translate(2.5rem, 1rem) scale(1)', // Moved further to the right
-                      },
-                      '& .MuiInputLabel-root.Mui-focused, & .MuiInputLabel-root.MuiFormLabel-filled':
-                        {
-                          transform: 'translate(1rem, -0.5rem) scale(0.75)', // Shrinks and moves up
-                        },
-                      '& .MuiInputLabel-root.Mui-focused': {
-                        color: '#A2195E', // Focused label color
-                      },
-                    }}
-                  />
-                </div>
-
-                {/* Date Input */}
-                <div className='relative'>
-                  <Calendar className='w-5 h-5 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2' />
-                  <TextField
-                    fullWidth
-                    label='Due Date'
-                    type='date'
-                    variant='outlined'
-                    value={formData.dueDate}
-                    onChange={handleInputChange('dueDate')}
-                    required
-                    inputProps={{
-                      max: new Date().toISOString().split('T')[0],
-                    }}
-                    InputLabelProps={{
-                      shrink: true,
-                    }}
-                    sx={{
-                      '& .MuiOutlinedInput-root': {
-                        paddingLeft: '2.5rem',
-                        borderRadius: '12px',
-                        '&:hover fieldset': {
-                          borderColor: '#A2195E',
-                        },
-                        '&.Mui-focused fieldset': {
-                          borderColor: '#A2195E',
-                        },
-                      },
-                      '& .MuiInputLabel-root.Mui-focused': {
-                        color: '#A2195E',
-                      },
-                    }}
-                  />
-                </div>
-
-                {/* Consent Section */}
-                <div className='bg-gray-50 rounded-xl p-4 border border-gray-100'>
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        checked={formData.consent}
-                        onChange={(e) =>
-                          setFormData({
-                            ...formData,
-                            consent: e.target.checked,
-                          })
-                        }
-                        required
-                        sx={{
-                          color: '#A2195E',
-                          '&.Mui-checked': {
-                            color: '#A2195E',
-                          },
-                        }}
-                      />
-                    }
-                    label={
-                      <Typography variant='body2' className='text-gray-700'>
-                        {formData.reportType === 'recovery_service'
-                          ? 'I hereby give consent to make recovery calls on my behalf and agree to the recovery process'
-                          : 'I hereby confirm that the information provided is accurate and can be used to warn other lenders'}
-                      </Typography>
-                    }
-                  />
-                </div>
-
-                {/* Submit Button */}
-                <motion.div whileTap={{ scale: 0.98 }} className='pt-4'>
-                  <Button
-                    type='submit'
-                    variant='contained'
-                    fullWidth
-                    size='large'
-                    disabled={!formData.consent || !!warningMessage}
-                    sx={{
-                      height: '56px',
-                      background: 'linear-gradient(to right, #A2195E, #8B1550)',
-                      '&:hover': {
-                        background:
-                          'linear-gradient(to right, #8B1550, #A2195E)',
-                      },
-                      '&:disabled': {
-                        background: '#e0e0e0',
-                        opacity: 0.7,
-                        cursor: 'not-allowed',
-                      },
-                      borderRadius: '14px',
-                      textTransform: 'none',
-                      fontSize: '1.1rem',
-                      fontWeight: '600',
-                      boxShadow:
-                        '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
-                    }}
-                  >
-                    {formData.reportType === 'recovery_service'
-                      ? 'Submit Report & Start Recovery'
-                      : 'Submit Report'}
-                  </Button>
-                </motion.div>
-              </form>
+              <ReportForm
+                formData={formData}
+                warningMessage={warningMessage}
+                onSubmit={handleSubmit}
+                onChange={handleInputChange}
+              />
             </div>
           </motion.div>
         </Container>
       </div>
 
-      {/* Report Only Modal */}
-      <Modal
+      <InfoModal
         open={openReportModal}
         onClose={() => setOpenReportModal(false)}
-        aria-labelledby='report-only-modal'
-        aria-describedby='report-only-description'
+        title='Why Report a Defaulter?'
+        description='Has someone broken your trust by not returning borrowed money? Help protect others from experiencing the same by reporting the defaulter.'
       >
-        <Box
-          sx={{
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            width: '95%',
-            maxWidth: '600px',
-            bgcolor: 'background.paper',
-            borderRadius: '20px',
-            boxShadow:
-              '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
-            p: { xs: 3, sm: 4 },
-            maxHeight: { xs: '85vh', sm: '90vh' },
-            overflow: 'auto',
-            '&:focus': {
-              outline: 'none',
-            },
-          }}
-        >
-          <div className='flex items-center justify-between mb-4'>
-            <Typography
-              variant='h6'
-              component='h2'
-              sx={{
-                color: '#A2195E',
-                fontWeight: 600,
-                fontSize: { xs: '1.1rem', sm: '1.25rem' },
-              }}
-            >
-              Why Report a Defaulter?
-            </Typography>
-            <IconButton
-              onClick={() => setOpenReportModal(false)}
-              sx={{
-                color: 'gray',
-                '&:hover': { color: '#A2195E' },
-              }}
-            >
-              <X className='w-5 h-5' />
-            </IconButton>
-          </div>
+        <ReportModalContent />
+      </InfoModal>
 
-          {/* Important Notice */}
-          <div className='bg-orange-50 rounded-xl p-3 mb-5 border border-orange-200'>
-            <div className='flex gap-2'>
-              <AlertCircle className='w-5 h-5 text-orange-500 flex-shrink-0 mt-0.5' />
-              <Typography
-                variant='body2'
-                sx={{
-                  color: 'rgb(194,65,12)',
-                  fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                }}
-              >
-                Has someone broken your trust by not returning borrowed money?
-                Help protect others from experiencing the same by reporting the
-                defaulter.
-              </Typography>
-            </div>
-          </div>
-
-          <div className='space-y-4'>
-            {/* Benefits */}
-            <div className='relative'>
-              {/* Vertical Line */}
-              <div className='absolute left-4 top-4 bottom-4 w-0.5 bg-pink-100'></div>
-
-              {/* Points */}
-              <div className='space-y-6'>
-                <div className='flex gap-3'>
-                  <div className='w-8 h-8 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0 relative z-10'>
-                    <Shield className='w-4 h-4 text-[#A2195E]' />
-                  </div>
-                  <div className='flex-1'>
-                    <Typography
-                      variant='subtitle1'
-                      sx={{
-                        fontWeight: 600,
-                        mb: 0.5,
-                        fontSize: { xs: '0.9375rem', sm: '1rem' },
-                      }}
-                    >
-                      Protect the Community
-                    </Typography>
-                    <Typography
-                      variant='body2'
-                      sx={{
-                        color: 'text.secondary',
-                        fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                      }}
-                    >
-                      Your report helps other lenders make informed decisions
-                      before lending money. This creates a safer lending
-                      environment for everyone.
-                    </Typography>
-                  </div>
-                </div>
-
-                <div className='flex gap-3'>
-                  <div className='w-8 h-8 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0 relative z-10'>
-                    <AlertCircle className='w-4 h-4 text-[#A2195E]' />
-                  </div>
-                  <div className='flex-1'>
-                    <Typography
-                      variant='subtitle1'
-                      sx={{
-                        fontWeight: 600,
-                        mb: 0.5,
-                        fontSize: { xs: '0.9375rem', sm: '1rem' },
-                      }}
-                    >
-                      Early Warning System
-                    </Typography>
-                    <Typography
-                      variant='body2'
-                      sx={{
-                        color: 'text.secondary',
-                        fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                      }}
-                    >
-                      When someone checks a borrower's history, they'll see your
-                      report as a warning sign, helping them avoid potential
-                      defaults.
-                    </Typography>
-                  </div>
-                </div>
-
-                <div className='flex gap-3'>
-                  <div className='w-8 h-8 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0 relative z-10'>
-                    <PhoneCall className='w-4 h-4 text-[#A2195E]' />
-                  </div>
-                  <div className='flex-1'>
-                    <Typography
-                      variant='subtitle1'
-                      sx={{
-                        fontWeight: 600,
-                        mb: 0.5,
-                        fontSize: { xs: '0.9375rem', sm: '1rem' },
-                      }}
-                    >
-                      Future Recovery Options
-                    </Typography>
-                    <Typography
-                      variant='body2'
-                      sx={{
-                        color: 'text.secondary',
-                        fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                      }}
-                    >
-                      Even if you choose to only report now, you can always opt
-                      for our recovery service later if needed.
-                    </Typography>
-                  </div>
-                </div>
-
-                <div className='flex gap-3'>
-                  <div className='w-8 h-8 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0 relative z-10'>
-                    <Users className='w-4 h-4 text-[#A2195E]' />
-                  </div>
-                  <div className='flex-1'>
-                    <Typography
-                      variant='subtitle1'
-                      sx={{
-                        fontWeight: 600,
-                        mb: 0.5,
-                        fontSize: { xs: '0.9375rem', sm: '1rem' },
-                      }}
-                    >
-                      Build Trust
-                    </Typography>
-                    <Typography
-                      variant='body2'
-                      sx={{
-                        color: 'text.secondary',
-                        fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                      }}
-                    >
-                      Your report contributes to building a trusted lending
-                      community. Together, we can make informal lending safer
-                      for everyone.
-                    </Typography>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <Button
-            onClick={() => setOpenReportModal(false)}
-            fullWidth
-            variant='contained'
-            sx={{
-              mt: 4,
-              height: { xs: '44px', sm: '48px' },
-              background: 'linear-gradient(to right, #A2195E, #8B1550)',
-              '&:hover': {
-                background: 'linear-gradient(to right, #8B1550, #A2195E)',
-              },
-              borderRadius: '12px',
-              textTransform: 'none',
-              fontSize: { xs: '0.9375rem', sm: '1rem' },
-              fontWeight: '600',
-            }}
-          >
-            Got it
-          </Button>
-        </Box>
-      </Modal>
-
-      {/* Recovery Service Process Modal */}
-      <Modal
+      <InfoModal
         open={openRecoveryModal}
         onClose={() => setOpenRecoveryModal(false)}
-        aria-labelledby='recovery-process-modal'
-        aria-describedby='recovery-process-description'
+        title='Recovery Service Process'
+        description="We understand that informal lending is often based on trust. While having proof of lending (like messages, transactions, or documents) increases recovery chances, we'll still assist even without formal documentation."
       >
-        <Box
-          sx={{
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            width: '95%',
-            maxWidth: '600px',
-            bgcolor: 'background.paper',
-            borderRadius: '20px',
-            boxShadow:
-              '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
-            p: { xs: 3, sm: 4 },
-            maxHeight: { xs: '85vh', sm: '90vh' },
-            overflow: 'auto',
-            '&:focus': {
-              outline: 'none',
-            },
-          }}
-        >
-          <div className='flex items-center justify-between mb-4'>
-            <Typography
-              variant='h6'
-              component='h2'
-              sx={{
-                color: '#A2195E',
-                fontWeight: 600,
-                fontSize: { xs: '1.1rem', sm: '1.25rem' },
-              }}
-            >
-              Recovery Service Process
-            </Typography>
-            <IconButton
-              onClick={() => setOpenRecoveryModal(false)}
-              sx={{
-                color: 'gray',
-                '&:hover': { color: '#A2195E' },
-              }}
-            >
-              <X className='w-5 h-5' />
-            </IconButton>
-          </div>
+        <RecoveryModalContent />
+      </InfoModal>
 
-          {/* Important Notice */}
-          <div className='bg-orange-50 rounded-xl p-3 mb-5 border border-orange-200'>
-            <div className='flex gap-2'>
-              <AlertCircle className='w-5 h-5 text-orange-500 flex-shrink-0 mt-0.5' />
-              <Typography
-                variant='body2'
-                sx={{
-                  color: 'rgb(194,65,12)',
-                  fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                }}
-              >
-                We understand that informal lending is often based on trust.
-                While having proof of lending (like messages, transactions, or
-                documents) increases recovery chances, we'll still assist even
-                without formal documentation.
-              </Typography>
-            </div>
-          </div>
-
-          <div className='space-y-4'>
-            {/* Process Steps */}
-            <div className='relative'>
-              {/* Vertical Line */}
-              <div className='absolute left-4 top-4 bottom-4 w-0.5 bg-pink-100'></div>
-
-              {/* Steps */}
-              <div className='space-y-6'>
-                <div className='flex gap-3'>
-                  <div className='w-8 h-8 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0 relative z-10'>
-                    <span className='text-[#A2195E] font-semibold'>1</span>
-                  </div>
-                  <div className='flex-1'>
-                    <Typography
-                      variant='subtitle1'
-                      sx={{
-                        fontWeight: 600,
-                        mb: 0.5,
-                        fontSize: { xs: '0.9375rem', sm: '1rem' },
-                      }}
-                    >
-                      Initial Verification
-                    </Typography>
-                    <Typography
-                      variant='body2'
-                      sx={{
-                        color: 'text.secondary',
-                        fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                      }}
-                    >
-                      To prevent fraudulent reports, we first verify with the
-                      borrower about receiving the loan. Their acknowledgment
-                      serves as proof for proceeding with recovery. This step
-                      protects both genuine lenders and borrowers.
-                    </Typography>
-                  </div>
-                </div>
-
-                <div className='flex gap-3'>
-                  <div className='w-8 h-8 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0 relative z-10'>
-                    <span className='text-[#A2195E] font-semibold'>2</span>
-                  </div>
-                  <div className='flex-1'>
-                    <Typography
-                      variant='subtitle1'
-                      sx={{
-                        fontWeight: 600,
-                        mb: 0.5,
-                        fontSize: { xs: '0.9375rem', sm: '1rem' },
-                      }}
-                    >
-                      Documentation Review
-                    </Typography>
-                    <Typography
-                      variant='body2'
-                      sx={{
-                        color: 'text.secondary',
-                        fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                      }}
-                    >
-                      If you have any proof of lending (WhatsApp messages, UPI
-                      transactions, written notes, etc.), you can provide them
-                      to strengthen the recovery case. However, this is optional
-                      and we'll proceed even without formal documentation.
-                    </Typography>
-                  </div>
-                </div>
-
-                <div className='flex gap-3'>
-                  <div className='w-8 h-8 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0 relative z-10'>
-                    <span className='text-[#A2195E] font-semibold'>3</span>
-                  </div>
-                  <div className='flex-1'>
-                    <Typography
-                      variant='subtitle1'
-                      sx={{
-                        fontWeight: 600,
-                        mb: 0.5,
-                        fontSize: { xs: '0.9375rem', sm: '1rem' },
-                      }}
-                    >
-                      Professional Communication
-                    </Typography>
-                    <Typography
-                      variant='body2'
-                      sx={{
-                        color: 'text.secondary',
-                        fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                      }}
-                    >
-                      Once verified, our recovery experts initiate professional
-                      communication with the borrower through calls and
-                      messages. We maintain a respectful approach while
-                      representing you.
-                    </Typography>
-                  </div>
-                </div>
-
-                <div className='flex gap-3'>
-                  <div className='w-8 h-8 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0 relative z-10'>
-                    <span className='text-[#A2195E] font-semibold'>4</span>
-                  </div>
-                  <div className='flex-1'>
-                    <Typography
-                      variant='subtitle1'
-                      sx={{
-                        fontWeight: 600,
-                        mb: 0.5,
-                        fontSize: { xs: '0.9375rem', sm: '1rem' },
-                      }}
-                    >
-                      Resolution & Recovery
-                    </Typography>
-                    <Typography
-                      variant='body2'
-                      sx={{
-                        color: 'text.secondary',
-                        fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                      }}
-                    >
-                      We work to establish a repayment plan and facilitate the
-                      recovery of your funds through a structured and
-                      professional approach.
-                    </Typography>
-                  </div>
-                </div>
-
-                <div className='flex gap-3'>
-                  <div className='w-8 h-8 rounded-full bg-pink-100 flex items-center justify-center flex-shrink-0 relative z-10'>
-                    <span className='text-[#A2195E] font-semibold'>5</span>
-                  </div>
-                  <div className='flex-1'>
-                    <Typography
-                      variant='subtitle1'
-                      sx={{
-                        fontWeight: 600,
-                        mb: 0.5,
-                        fontSize: { xs: '0.9375rem', sm: '1rem' },
-                      }}
-                    >
-                      Progress Updates
-                    </Typography>
-                    <Typography
-                      variant='body2'
-                      sx={{
-                        color: 'text.secondary',
-                        fontSize: { xs: '0.875rem', sm: '0.9375rem' },
-                      }}
-                    >
-                      You'll receive regular updates about the recovery progress
-                      through our platform, keeping you informed at every step
-                      of the process.
-                    </Typography>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <Button
-            onClick={() => setOpenRecoveryModal(false)}
-            fullWidth
-            variant='contained'
-            sx={{
-              mt: 4,
-              height: { xs: '44px', sm: '48px' },
-              background: 'linear-gradient(to right, #A2195E, #8B1550)',
-              '&:hover': {
-                background: 'linear-gradient(to right, #8B1550, #A2195E)',
-              },
-              borderRadius: '12px',
-              textTransform: 'none',
-              fontSize: { xs: '0.9375rem', sm: '1rem' },
-              fontWeight: '600',
-            }}
-          >
-            Got it
-          </Button>
-        </Box>
-      </Modal>
+      <KYCDialog
+        isOpen={showKYCDialog}
+        onClose={() => setShowKYCDialog(false)}
+        title='KYC Required'
+        description='To report a borrower, you need to complete the KYC process first.'
+      />
     </div>
   );
 }

--- a/app/(root)/request/page.tsx
+++ b/app/(root)/request/page.tsx
@@ -1,214 +1,48 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ProfileSelector } from '@/components/shared/profile-selector';
+import { LoanForm } from '@/components/shared/loan-form';
+import { SuccessState } from '@/components/shared/success-state';
+import { useLoanForm } from '@/hooks/use-loan-form';
+import { useUser } from '@/contexts/UserContext';
 import {
-  Box,
-  Typography,
-  TextField,
-  Button,
-  Grid,
-  Radio,
-  RadioGroup,
-  FormControlLabel,
-  Select,
-  MenuItem,
-} from '@mui/material';
-import { styled } from '@mui/material/styles';
-import RequestLoanAppBar from '../../../components/RequestLoanAppBar';
-import NavBar from '../../../components/NavBar';
-import Image from 'next/image';
-import { motion, AnimatePresence } from 'framer-motion';
-import {
-  CheckCircleIcon,
   ChartBarIcon,
   ClockIcon,
   UserGroupIcon,
-  InformationCircleIcon,
 } from '@heroicons/react/24/outline';
-import ReactConfetti from 'react-confetti';
-import { auth } from '../../lib/firebase';
+import api from '@/utils/api';
+import RequestLoanAppBar from '@/components/RequestLoanAppBar';
+import NavBar from '@/components/NavBar';
+import KYCDialog from '@/components/KYCdialog';
 
-const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-interface Profile {
-  id: string;
-  name: string;
-  mobile: string;
-  image: string;
-}
-
-const StyledTextField = styled(TextField)({
-  '& .MuiOutlinedInput-root': {
-    borderRadius: '12px',
-    backgroundColor: '#F9F9F9',
-    '& fieldset': {
-      borderColor: '#E5E5E5',
-    },
-    '&:hover fieldset': {
-      borderColor: '#A2195E',
-    },
-    '&.Mui-focused fieldset': {
-      borderColor: '#A2195E',
-    },
-  },
-  '& .MuiInputLabel-root': {
-    color: '#666666',
-    '&.Mui-focused': {
-      color: '#A2195E',
-    },
-  },
-});
-
-const RequestLoanPage = () => {
-  const [savedProfiles, setSavedProfiles] = useState<Profile[]>([]);
-  const [requestType, setRequestType] = useState('saved');
-  const [selectedProfile, setSelectedProfile] = useState<number | null>(null);
-  const [mobileNumber, setMobileNumber] = useState('');
-  const [warningMessage, setWarningMessage] = useState<string | null>(null);
-  const [isSuccess, setIsSuccess] = useState(false);
+export default function RequestLoanPage() {
+  const router = useRouter();
+  const { userProfile } = useUser();
+  const { formData, updateFormData } = useLoanForm('request');
   const [showLoanForm, setShowLoanForm] = useState(false);
-  const [timeUnit, setTimeUnit] = useState('month');
-  const [interestRate, setInterestRate] = useState('');
-  const [paymentType, setPaymentType] = useState('onetime');
-  const [emiFrequency, setEmiFrequency] = useState('monthly');
-  const [loanAmount, setLoanAmount] = useState('');
-  const [loanTerm, setLoanTerm] = useState('');
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
-  const [selectedLender, setSelectedLender] = useState('ABC Finance');
-  const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
+  const [showKYCDialog, setShowKYCDialog] = useState(false);
 
-  useEffect(() => {
-    const profiles = localStorage.getItem('savedProfiles');
-    if (profiles) {
-      const parsedProfiles = JSON.parse(profiles);
-      // Ensure each profile has an image, if not set a default one
-      const profilesWithImages = parsedProfiles.map((profile: any) => ({
-        ...profile,
-        image: profile.image || '/images/saved-profiles.svg',
-      }));
-      setSavedProfiles(profilesWithImages);
-    }
-  }, []);
-
-  useEffect(() => {
-    setWindowSize({
-      width: window.innerWidth,
-      height: window.innerHeight,
-    });
-  }, []);
-
-  const calculateEMI = () => {
-    if (!loanAmount || !interestRate || !loanTerm) return 0;
-
-    const principal = parseFloat(loanAmount);
-    const ratePerPeriod =
-      parseFloat(interestRate) / 100 / (emiFrequency === 'daily' ? 365 : 12);
-    let numberOfPayments: number;
-
-    if (timeUnit === 'year') {
-      numberOfPayments =
-        emiFrequency === 'daily'
-          ? 365 * parseFloat(loanTerm)
-          : 12 * parseFloat(loanTerm);
-    } else if (timeUnit === 'month') {
-      numberOfPayments =
-        emiFrequency === 'daily'
-          ? 30 * parseFloat(loanTerm)
-          : parseFloat(loanTerm);
-    } else {
-      // days
-      numberOfPayments =
-        emiFrequency === 'daily'
-          ? parseFloat(loanTerm)
-          : parseFloat(loanTerm) / 30;
+  const handleSubmit = async () => {
+    if (userProfile?.plan === 'FREE' || !userProfile?.credit_score_enabled) {
+      setShowKYCDialog(true);
+      return;
     }
 
-    const emi =
-      (principal *
-        ratePerPeriod *
-        Math.pow(1 + ratePerPeriod, numberOfPayments)) /
-      (Math.pow(1 + ratePerPeriod, numberOfPayments) - 1);
-
-    return isNaN(emi) ? 0 : emi;
-  };
-
-  const emiAmount = calculateEMI();
-
-  const handleRequestTypeChange = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setRequestType(event.target.value);
-    setSelectedProfile(null);
-    setMobileNumber('');
-  };
-
-  const handleProfileSelect = (profileId: number) => {
-    setSelectedProfile(profileId);
-  };
-
-  const handleContinue = () => {
-    if (requestType === 'saved' && selectedProfile) {
-      setShowLoanForm(true);
-    } else if (requestType === 'new' && mobileNumber.length === 10) {
-      setShowLoanForm(true);
-    }
-  };
-
-  const handleSubmit = (event: React.FormEvent) => {
-    event.preventDefault();
-    // Handle loan request submission logic here
-    setShowSuccessMessage(true);
-  };
-
-  const handleMobileNumberChange = async (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const cleanNumber = e.target.value.replace(/[^\d]/g, '').slice(0, 10);
-    setMobileNumber(cleanNumber);
-    setWarningMessage(null);
-    setIsSuccess(false);
-
-    if (cleanNumber.length === 10) {
-      try {
-        const user = auth.currentUser;
-        if (!user) {
-          console.error('User not authenticated');
-          return;
-        }
-
-        const idToken = await user.getIdToken(true);
-        const formattedNumber = `+91${cleanNumber}`;
-
-        const apiUrl = `${baseURL}/search/mobile/${formattedNumber}`;
-        console.log('Calling API endpoint:', apiUrl);
-
-        const response = await fetch(apiUrl, {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${idToken}`,
-            'Content-Type': 'application/json',
-          },
-        });
-
-        if (!response.ok) {
-          if (response.status === 404) {
-            setWarningMessage(
-              'The person you are requesting credit from is not currently onboarded in Credmate. We will reach out to them through WhatsApp, SMS, and call to let them know about your credit request.'
-            );
-            setIsSuccess(false);
-          } else {
-            throw new Error(`HTTP error! status: ${response.status}`);
-          }
-        } else {
-          const data = await response.json();
-          if (data.name) {
-            setWarningMessage(`You are requesting credit from ${data.name}`);
-            setIsSuccess(true);
-          }
-        }
-      } catch (error) {
-        console.error('Error fetching data:', error);
-        setIsSuccess(false);
-      }
+    try {
+      await api.post('/loan/request', {
+        loanAmount: Number(formData.loanAmount),
+        interestRate: Number(formData.interestRate),
+        paymentType: formData.paymentType,
+        emiFrequency: formData.emiFrequency,
+        loanTerm: Number(formData.loanTerm),
+        timeUnit: formData.timeUnit,
+      });
+      setShowSuccessMessage(true);
+    } catch (error) {
+      console.error('Error submitting request:', error);
     }
   };
 
@@ -216,314 +50,29 @@ const RequestLoanPage = () => {
     return (
       <div className='flex flex-col min-h-screen bg-gradient-to-br from-white via-pink-50 to-purple-50'>
         <RequestLoanAppBar />
-        <ReactConfetti
-          width={windowSize.width}
-          height={windowSize.height}
-          recycle={false}
-          numberOfPieces={200}
-          gravity={0.2}
-        />
         <main className='flex-1 overflow-y-auto'>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className='px-6 pt-10 pb-24 flex flex-col items-center justify-center min-h-full'
-          >
-            <motion.div
-              initial={{ scale: 0 }}
-              animate={{ scale: 1 }}
-              transition={{ type: 'spring', stiffness: 200, damping: 15 }}
-              className='w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mb-6'
-            >
-              <CheckCircleIcon className='w-12 h-12 text-green-600' />
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2 }}
-              className='text-center'
-            >
-              <h2 className='text-3xl font-bold text-gray-800 mb-4'>
-                Request Submitted Successfully! 🎉
-              </h2>
-              <p className='text-lg text-gray-600 max-w-md mb-8'>
-                Your P2P lending request has been sent to potential lenders in
-                our network.
-              </p>
-            </motion.div>
-
-            <div className='grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-4xl'>
-              {[
-                {
-                  icon: <UserGroupIcon className='w-8 h-8' />,
-                  title: 'Matching Process',
-                  description: "We're matching you with the best P2P lenders",
-                },
-                {
-                  icon: <ClockIcon className='w-8 h-8' />,
-                  title: 'Quick Response',
-                  description: 'Expect responses within 24-48 hours',
-                },
-                {
-                  icon: <ChartBarIcon className='w-8 h-8' />,
-                  title: 'Next Steps',
-                  description: 'Contract review and digital signing process',
-                },
-              ].map((item, index) => (
-                <motion.div
-                  key={index}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.4 + index * 0.1 }}
-                  className='bg-white p-6 rounded-2xl shadow-lg hover:shadow-xl transition-shadow duration-300'
-                >
-                  <div className='w-12 h-12 bg-pink-100 rounded-full flex items-center justify-center mb-4'>
-                    <div className='text-pink-600'>{item.icon}</div>
-                  </div>
-                  <h3 className='text-lg font-semibold text-gray-800 mb-2'>
-                    {item.title}
-                  </h3>
-                  <p className='text-gray-600'>{item.description}</p>
-                </motion.div>
-              ))}
-            </div>
-
-            <motion.button
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ delay: 0.8 }}
-              onClick={() => (window.location.href = '/dashboard')}
-              className='mt-8 px-8 py-3 bg-pink-600 text-white rounded-full font-medium hover:bg-pink-700 transition-colors duration-300'
-            >
-              Go to Dashboard
-            </motion.button>
-          </motion.div>
-        </main>
-        <NavBar />
-      </div>
-    );
-  }
-
-  if (!showLoanForm) {
-    return (
-      <div className='flex flex-col min-h-screen bg-gradient-to-br from-white via-pink-50 to-purple-50'>
-        <RequestLoanAppBar />
-        <main className='flex-1 overflow-y-auto pt-20 pb-24 px-4'>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className='max-w-lg mx-auto'
-          >
-            <div className='bg-white rounded-3xl shadow-lg p-6 mb-6'>
-              <h2 className='text-2xl font-bold text-gray-800 mb-6 text-center'>
-                Request a Loan
-              </h2>
-
-              <RadioGroup
-                value={requestType}
-                onChange={handleRequestTypeChange}
-                className='mb-6'
-              >
-                <div className='grid grid-cols-2 gap-4'>
-                  <motion.div whileTap={{ scale: 0.98 }}>
-                    <FormControlLabel
-                      value='saved'
-                      control={<Radio />}
-                      label={
-                        <div className='flex flex-col items-center p-4 bg-pink-50 rounded-xl cursor-pointer transition-all hover:bg-pink-100 min-h-[120px] w-full justify-center'>
-                          <div className='w-12 h-12 rounded-full bg-pink-200 flex items-center justify-center flex-shrink-0'>
-                            <Image
-                              src='/images/savedborrowers.svg'
-                              alt='Saved Profiles'
-                              width={32}
-                              height={32}
-                              className='mb-2 mt-2'
-                            />
-                          </div>
-                          <span className='font-medium text-gray-800'>
-                            Saved Lenders
-                          </span>
-                        </div>
-                      }
-                      className='m-0 w-full'
-                    />
-                  </motion.div>
-
-                  <motion.div whileTap={{ scale: 0.98 }}>
-                    <FormControlLabel
-                      value='new'
-                      control={<Radio />}
-                      label={
-                        <div className='flex flex-col items-center p-4 bg-pink-50 rounded-xl cursor-pointer transition-all hover:bg-pink-100 min-h-[120px] w-full justify-center'>
-                          <div className='w-12 h-12 rounded-full bg-pink-200 flex items-center justify-center flex-shrink-0'>
-                            <Image
-                              src='/images/newborrower.svg'
-                              alt='New Profile'
-                              width={32}
-                              height={32}
-                              className='mb-2 mt-1'
-                            />
-                          </div>
-                          <span className='font-medium text-gray-800'>
-                            Other Lender
-                          </span>
-                        </div>
-                      }
-                      className='m-0 w-full'
-                    />
-                  </motion.div>
-                </div>
-              </RadioGroup>
-
-              <AnimatePresence mode='wait'>
-                {requestType === 'saved' ? (
-                  <motion.div
-                    key='saved'
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                  >
-                    <div className='space-y-4'>
-                      {savedProfiles.map((profile) => (
-                        <motion.div
-                          key={profile.id}
-                          whileHover={{ scale: 1.02 }}
-                          whileTap={{ scale: 0.98 }}
-                          onClick={() =>
-                            handleProfileSelect(parseInt(profile.id, 10))
-                          }
-                          className={`p-4 rounded-xl border-2 transition-all cursor-pointer ${
-                            selectedProfile === parseInt(profile.id, 10)
-                              ? 'border-pink-500 bg-pink-50'
-                              : 'border-gray-200 hover:border-pink-200'
-                          }`}
-                        >
-                          <div className='flex items-center space-x-4'>
-                            <div className='w-12 h-12 rounded-full overflow-hidden bg-gray-100'>
-                              <Image
-                                src={profile.image}
-                                alt={profile.name}
-                                width={48}
-                                height={48}
-                                className='object-cover'
-                              />
-                            </div>
-                            <div>
-                              <h3 className='font-semibold text-gray-800'>
-                                {profile.name}
-                              </h3>
-                              <p className='text-sm text-gray-500'>
-                                {profile.mobile}
-                              </p>
-                            </div>
-                          </div>
-                        </motion.div>
-                      ))}
-                    </div>
-                  </motion.div>
-                ) : (
-                  <motion.div
-                    key='new'
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                  >
-                    <StyledTextField
-                      fullWidth
-                      label='Mobile Number'
-                      variant='outlined'
-                      value={mobileNumber}
-                      onChange={handleMobileNumberChange}
-                      placeholder='Enter 10-digit number'
-                      inputProps={{
-                        maxLength: 10,
-                        pattern: '[0-9]*',
-                      }}
-                      className='mb-4'
-                    />
-                    {warningMessage && (
-                      <motion.div
-                        initial={{ opacity: 0, y: -10 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        className={`flex items-center p-4 mb-4 rounded-lg ${
-                          isSuccess
-                            ? 'bg-green-50 text-green-800'
-                            : 'bg-yellow-50 text-yellow-800'
-                        }`}
-                      >
-                        {isSuccess ? (
-                          <CheckCircleIcon className='w-5 h-5 mr-2 text-green-600' />
-                        ) : (
-                          <InformationCircleIcon className='w-5 h-5 mr-2 text-yellow-600' />
-                        )}
-                        <span className='text-sm'>{warningMessage}</span>
-                      </motion.div>
-                    )}
-                  </motion.div>
-                )}
-              </AnimatePresence>
-
-              <motion.button
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-                onClick={handleContinue}
-                disabled={
-                  !(requestType === 'saved' && selectedProfile) &&
-                  !(requestType === 'new' && mobileNumber.length === 10)
-                }
-                className={`w-full py-4 rounded-xl font-semibold text-white transition-all
-                  ${
-                    (requestType === 'saved' && selectedProfile) ||
-                    (requestType === 'new' && mobileNumber.length === 10)
-                      ? 'bg-pink-600 hover:bg-pink-700'
-                      : 'bg-gray-300 cursor-not-allowed'
-                  }`}
-              >
-                Continue
-              </motion.button>
-            </div>
-
-            <div className='bg-gradient-to-r from-pink-50 to-purple-50 rounded-3xl p-6'>
-              <h3 className='font-semibold text-gray-800 mb-4'>
-                Why Choose Credmate?
-              </h3>
-              <div className='space-y-4'>
-                {[
-                  {
-                    title: 'Credit Health',
-                    desc: 'Doing credit transactions through Credmate improve credit health',
-                  },
-                  {
-                    title: 'Secure Process',
-                    desc: 'End-to-end encrypted loan processing',
-                  },
-                  {
-                    title: 'More Opportunities',
-                    desc: 'Get exposure to more loan offers',
-                  },
-                ].map((item, index) => (
-                  <motion.div
-                    key={index}
-                    initial={{ opacity: 0, x: -20 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    transition={{ delay: index * 0.1 }}
-                    className='flex items-start space-x-3'
-                  >
-                    <div className='w-6 h-6 rounded-full bg-pink-200 flex items-center justify-center flex-shrink-0'>
-                      <span className='text-pink-700 text-sm'>✓</span>
-                    </div>
-                    <div>
-                      <h4 className='font-medium text-gray-800'>
-                        {item.title}
-                      </h4>
-                      <p className='text-sm text-gray-600'>{item.desc}</p>
-                    </div>
-                  </motion.div>
-                ))}
-              </div>
-            </div>
-          </motion.div>
+          <SuccessState
+            title='Request Submitted Successfully! 🎉'
+            description='Your P2P lending request has been sent to potential lenders in our network.'
+            steps={[
+              {
+                icon: <UserGroupIcon className='w-8 h-8' />,
+                title: 'Matching Process',
+                description: "We're matching you with the best P2P lenders",
+              },
+              {
+                icon: <ClockIcon className='w-8 h-8' />,
+                title: 'Quick Response',
+                description: 'Expect responses within 24-48 hours',
+              },
+              {
+                icon: <ChartBarIcon className='w-8 h-8' />,
+                title: 'Next Steps',
+                description: 'Contract review and digital signing process',
+              },
+            ]}
+            onDashboardClick={() => router.push('/dashboard')}
+          />
         </main>
         <NavBar />
       </div>
@@ -533,249 +82,34 @@ const RequestLoanPage = () => {
   return (
     <div className='flex flex-col min-h-screen bg-gradient-to-br from-white via-pink-50 to-purple-50'>
       <RequestLoanAppBar />
-      <main className='flex-1 overflow-y-auto pt-20 pb-24 px-4'>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className='max-w-lg mx-auto'
-        >
-          <form onSubmit={handleSubmit} className='space-y-6'>
-            <div className='bg-white rounded-3xl shadow-lg p-6'>
-              <h2 className='text-2xl font-bold text-gray-800 mb-6'>
-                Loan Details
-              </h2>
-
-              <div className='space-y-6'>
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-2'>
-                    Loan Amount
-                  </label>
-                  <div className='relative'>
-                    <div className='absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none'>
-                      <span className='text-gray-500'>₹</span>
-                    </div>
-                    <StyledTextField
-                      fullWidth
-                      type='number'
-                      value={loanAmount}
-                      onChange={(e) => setLoanAmount(e.target.value)}
-                      placeholder='Enter amount'
-                      InputProps={{
-                        startAdornment: (
-                          <span className='text-gray-500 mr-2'>₹</span>
-                        ),
-                      }}
-                      className='mb-1'
-                    />
-                  </div>
-                  <p className='text-sm text-gray-500 mt-1'>
-                    Min: ₹1,000 | Max: ₹10,00,000
-                  </p>
-                </div>
-
-                <div className='grid grid-cols-2 gap-4'>
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Loan Term
-                    </label>
-                    <StyledTextField
-                      fullWidth
-                      type='number'
-                      value={loanTerm}
-                      onChange={(e) => setLoanTerm(e.target.value)}
-                      placeholder='Duration'
-                    />
-                  </div>
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Time Unit
-                    </label>
-                    <Select
-                      value={timeUnit}
-                      onChange={(e) => setTimeUnit(e.target.value)}
-                      className='w-full rounded-xl'
-                      sx={{
-                        borderRadius: '12px',
-                        '& .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#E5E5E5',
-                        },
-                        '&:hover .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#A2195E',
-                        },
-                        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#A2195E',
-                        },
-                      }}
-                    >
-                      <MenuItem value='month'>Months</MenuItem>
-                      <MenuItem value='year'>Years</MenuItem>
-                      <MenuItem value='day'>Days</MenuItem>
-                    </Select>
-                  </div>
-                </div>
-
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-2'>
-                    Interest Rate (% per annum)
-                  </label>
-                  <StyledTextField
-                    fullWidth
-                    type='number'
-                    value={interestRate}
-                    onChange={(e) => setInterestRate(e.target.value)}
-                    placeholder='Enter interest rate'
-                    InputProps={{
-                      endAdornment: <span className='text-gray-500'>%</span>,
-                    }}
-                  />
-                </div>
-
-                <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-4'>
-                    Payment Type
-                  </label>
-                  <div className='grid grid-cols-2 gap-4'>
-                    <motion.div whileTap={{ scale: 0.98 }}>
-                      <FormControlLabel
-                        value='onetime'
-                        control={
-                          <Radio
-                            checked={paymentType === 'onetime'}
-                            onChange={(e) => setPaymentType(e.target.value)}
-                          />
-                        }
-                        label={
-                          <div
-                            className={`flex flex-col items-center p-4 rounded-xl cursor-pointer transition-all
-                            ${paymentType === 'onetime' ? 'bg-pink-50' : 'bg-gray-50 hover:bg-gray-100'}`}
-                          >
-                            <Image
-                              src='/images/onetime-payment.svg'
-                              alt='One-time Payment'
-                              width={32}
-                              height={32}
-                              className='mb-2'
-                            />
-                            <span className='font-medium text-sm text-gray-800'>
-                              One-time Payment
-                            </span>
-                          </div>
-                        }
-                        className='m-0 w-full'
-                      />
-                    </motion.div>
-
-                    <motion.div whileTap={{ scale: 0.98 }}>
-                      <FormControlLabel
-                        value='emi'
-                        control={
-                          <Radio
-                            checked={paymentType === 'emi'}
-                            onChange={(e) => setPaymentType(e.target.value)}
-                          />
-                        }
-                        label={
-                          <div
-                            className={`flex flex-col items-center p-4 rounded-xl cursor-pointer transition-all
-                            ${paymentType === 'emi' ? 'bg-pink-50' : 'bg-gray-50 hover:bg-gray-100'}`}
-                          >
-                            <Image
-                              src='/images/emi-payment.svg'
-                              alt='EMI'
-                              width={32}
-                              height={32}
-                              className='mb-2'
-                            />
-                            <span className='font-medium text-sm text-gray-800'>
-                              EMI
-                            </span>
-                          </div>
-                        }
-                        className='m-0 w-full'
-                      />
-                    </motion.div>
-                  </div>
-                </div>
-
-                {paymentType === 'emi' && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                  >
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      EMI Frequency
-                    </label>
-                    <Select
-                      value={emiFrequency}
-                      onChange={(e) =>
-                        setEmiFrequency(e.target.value as string)
-                      }
-                      className='w-full rounded-xl'
-                      sx={{
-                        borderRadius: '12px',
-                        '& .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#E5E5E5',
-                        },
-                        '&:hover .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#A2195E',
-                        },
-                        '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                          borderColor: '#A2195E',
-                        },
-                      }}
-                    >
-                      <MenuItem value='daily'>Daily</MenuItem>
-                      <MenuItem value='weekly'>Weekly</MenuItem>
-                      <MenuItem value='monthly'>Monthly</MenuItem>
-                    </Select>
-                  </motion.div>
-                )}
-              </div>
-            </div>
-
-            {/* EMI Calculator Result */}
-            {paymentType === 'emi' && emiAmount > 0 && (
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                className='bg-gradient-to-r from-pink-600 to-purple-600 rounded-3xl p-6 text-white'
-              >
-                <h3 className='text-lg font-semibold mb-2'>EMI Calculator</h3>
-                <div className='flex justify-between items-center'>
-                  <div>
-                    <p className='text-sm opacity-90'>Estimated EMI Amount</p>
-                    <p className='text-2xl font-bold'>
-                      ₹{emiAmount.toFixed(2)}
-                    </p>
-                  </div>
-                  <div className='w-12 h-12 bg-white/20 rounded-full flex items-center justify-center'>
-                    <Image
-                      src='/images/calculator.svg'
-                      alt='Calculator'
-                      width={24}
-                      height={24}
-                    />
-                  </div>
-                </div>
-              </motion.div>
-            )}
-
-            {/* Submit Button */}
-            <motion.button
-              type='submit'
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
-              className='w-full py-4 bg-pink-600 text-white rounded-xl font-semibold hover:bg-pink-700 transition-colors'
-            >
-              Submit Request
-            </motion.button>
-          </form>
-        </motion.div>
+      <main className='flex-1 px-4 pt-20 pb-24 overflow-y-auto'>
+        {!showLoanForm ? (
+          <ProfileSelector
+            type='lender'
+            savedProfiles={[]}
+            onProfileSelect={(profile) => {
+              if (profile) setShowLoanForm(true);
+            }}
+            onMobileNumberSubmit={(mobile) => {
+              if (mobile.length === 10) setShowLoanForm(true);
+            }}
+          />
+        ) : (
+          <LoanForm
+            formData={formData}
+            onChange={updateFormData}
+            onSubmit={handleSubmit}
+            submitButtonText='Submit Request'
+          />
+        )}
       </main>
       <NavBar />
+      <KYCDialog
+        isOpen={showKYCDialog}
+        onClose={() => setShowKYCDialog(false)}
+        title='KYC Required for Loan Request'
+        description='To request loans, you need to complete the KYC process first.'
+      />
     </div>
   );
-};
-
-export default RequestLoanPage;
+}

--- a/components/CreditScoreGauge.tsx
+++ b/components/CreditScoreGauge.tsx
@@ -4,15 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { HelpCircle, Lock } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@/contexts/UserContext';
-import { set } from 'date-fns';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from './ui/dialog';
-import { Button } from './ui/button';
+import KYCDialog from './KYCdialog';
 
 interface CreditScoreGaugeProps {
   scoreType?: 'credmate' | 'cibil';
@@ -171,33 +163,10 @@ export default function CreditScoreGauge({ scoreType }: CreditScoreGaugeProps) {
         </div>
       </div>
 
-      <Dialog open={showKYCDialog} onOpenChange={setShowKYCDialog}>
-        <DialogContent className='sm:max-w-md'>
-          <DialogHeader>
-            <DialogTitle>Complete KYC Required</DialogTitle>
-            <DialogDescription>
-              To access your detailed credit report, you need to complete the
-              KYC process first. This helps us verify your identity and provide
-              accurate credit information.
-            </DialogDescription>
-          </DialogHeader>
-          <div className='flex flex-col gap-4 mt-4'>
-            <Button
-              onClick={() => router.push('/history')}
-              className='w-full bg-[#A2195E] hover:bg-[#894567]'
-            >
-              Start KYC Process
-            </Button>
-            <Button
-              variant='outline'
-              onClick={() => setShowKYCDialog(false)}
-              className='w-full'
-            >
-              Maybe Later
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <KYCDialog
+        isOpen={showKYCDialog}
+        onClose={() => setShowKYCDialog(false)}
+      />
     </>
   );
 }

--- a/components/GiveCreditAppBar.tsx
+++ b/components/GiveCreditAppBar.tsx
@@ -11,7 +11,11 @@ interface GiveCreditAppBarProps {
   isSubmitting: boolean;
 }
 
-export default function GiveCreditAppBar({ loanAmount, onProtectionPlanSelect, isSubmitting }: GiveCreditAppBarProps) {
+export default function GiveCreditAppBar({
+  loanAmount,
+  onProtectionPlanSelect,
+  isSubmitting,
+}: GiveCreditAppBarProps) {
   const router = useRouter();
   const [isProtectionSheetOpen, setIsProtectionSheetOpen] = useState(false);
   const [selectedPlan, setSelectedPlan] = useState('free');
@@ -34,22 +38,22 @@ export default function GiveCreditAppBar({ loanAmount, onProtectionPlanSelect, i
 
   return (
     <>
-      <div className="bg-gradient-to-r from-[#A2195E] to-[#8B1550] p-4">
-        <div className="flex items-center">
-          <div className="flex items-center gap-3">
-            <button 
+      <div className='bg-gradient-to-r from-[#A2195E] to-[#8B1550] p-4'>
+        <div className='flex items-center'>
+          <div className='flex items-center gap-3'>
+            <button
               onClick={handleBackClick}
-              className="text-white hover:opacity-80 transition-opacity"
+              className='text-white transition-opacity hover:opacity-80'
             >
               <Image
-                src="/images/searchprofileicons/arrowbendleft.svg"
-                alt="Back Icon"
-                width={24} 
+                src='/images/searchprofileicons/arrowbendleft.svg'
+                alt='Back Icon'
+                width={24}
                 height={24}
-                className="invert"
+                className='invert'
               />
             </button>
-            <span className="text-white text-lg font-medium">Give Credit</span>
+            <span className='text-lg font-medium text-white'>Give Credit</span>
           </div>
         </div>
       </div>

--- a/components/KYCDialog.tsx
+++ b/components/KYCDialog.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useUser } from '@/contexts/UserContext';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface KYCDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  redirectPath?: string;
+  title?: string;
+  description?: string;
+  primaryButtonText?: string;
+  secondaryButtonText?: string;
+}
+
+export default function KYCDialog({
+  isOpen,
+  onClose,
+  redirectPath,
+  title = 'Complete KYC Required',
+  description = 'To access your detailed credit report, you need to complete the KYC process first. This helps us verify your identity and provide accurate credit information.',
+  primaryButtonText = 'Start KYC Process',
+  secondaryButtonText = 'Maybe Later',
+}: KYCDialogProps) {
+  const router = useRouter();
+  const { userProfile } = useUser();
+
+  const handleRedirect = () => {
+    const path = redirectPath || `/profile/${userProfile?.id}`;
+    router.push(path);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className='sm:max-w-md'>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className='flex flex-col gap-4 mt-4'>
+          <Button
+            onClick={handleRedirect}
+            className='w-full bg-[#A2195E] hover:bg-[#894567]'
+          >
+            {primaryButtonText}
+          </Button>
+          <Button variant='outline' onClick={onClose} className='w-full'>
+            {secondaryButtonText}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ProtectionPlanSheet.tsx
+++ b/components/ProtectionPlanSheet.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import React from 'react';
-import { 
-  SwipeableDrawer, 
-  Typography, 
-  List, 
-  ListItem, 
-  ListItemText, 
+import {
+  SwipeableDrawer,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
   ListItemIcon,
   Radio,
   RadioGroup,
   FormControlLabel,
-  Divider
+  Divider,
 } from '@mui/material';
 import ShieldIcon from '@mui/icons-material/Shield';
 import SecurityIcon from '@mui/icons-material/Security';
@@ -32,7 +32,7 @@ const ProtectionPlanSheet: React.FC<ProtectionPlanSheetProps> = ({
   onOpen,
   onSelect,
   selectedPlan,
-  loanAmount
+  loanAmount,
 }) => {
   const handlePlanChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onSelect(event.target.value);
@@ -45,7 +45,11 @@ const ProtectionPlanSheet: React.FC<ProtectionPlanSheetProps> = ({
       description: 'Basic proof of transaction with no additional costs',
       icon: <ShieldIcon />,
       cost: 'Free',
-      features: ['Basic loan agreement documentation', 'Digital contract', 'No recovery support']
+      features: [
+        'Basic loan agreement documentation',
+        'Digital contract',
+        'No recovery support',
+      ],
     },
     {
       id: 'standard',
@@ -53,7 +57,11 @@ const ProtectionPlanSheet: React.FC<ProtectionPlanSheetProps> = ({
       description: '2% of loan amount for enhanced protection',
       icon: <SecurityIcon />,
       cost: `₹${Math.round(loanAmount * 0.02).toLocaleString()}`,
-      features: ['All Basic features', 'Priority support', 'Basic recovery assistance']
+      features: [
+        'All Basic features',
+        'Priority support',
+        'Basic recovery assistance',
+      ],
     },
     {
       id: 'premium',
@@ -61,13 +69,18 @@ const ProtectionPlanSheet: React.FC<ProtectionPlanSheetProps> = ({
       description: '5% of loan amount for comprehensive coverage',
       icon: <GppGoodIcon />,
       cost: `₹${Math.round(loanAmount * 0.05).toLocaleString()}`,
-      features: ['All Standard features', '24/7 dedicated support', 'Full recovery assistance', 'Legal documentation support']
-    }
+      features: [
+        'All Standard features',
+        '24/7 dedicated support',
+        'Full recovery assistance',
+        'Legal documentation support',
+      ],
+    },
   ];
 
   return (
     <SwipeableDrawer
-      anchor="bottom"
+      anchor='bottom'
       open={open}
       onClose={onClose}
       onOpen={onOpen}
@@ -76,43 +89,59 @@ const ProtectionPlanSheet: React.FC<ProtectionPlanSheetProps> = ({
         sx: {
           borderTopLeftRadius: '16px',
           borderTopRightRadius: '16px',
-          maxHeight: '90vh'
-        }
+          maxHeight: '90vh',
+        },
       }}
     >
-      <div className="px-4 py-6">
-        <Typography variant="h6" component="h2" className="mb-4 text-center font-semibold">
+      <div className='px-4 py-6'>
+        <Typography
+          variant='h6'
+          component='h2'
+          className='mb-4 text-center font-semibold'
+        >
           Select Protection Plan
         </Typography>
-        
+
         <RadioGroup value={selectedPlan} onChange={handlePlanChange}>
           <List>
             {plans.map((plan, index) => (
               <React.Fragment key={plan.id}>
-                <ListItem className="flex flex-col items-start p-4 hover:bg-gray-50 rounded-lg">
+                <ListItem className='flex flex-col items-start p-4 hover:bg-gray-50 rounded-lg'>
                   <FormControlLabel
                     value={plan.id}
                     control={<Radio />}
                     label={
-                      <div className="flex flex-col ml-2">
-                        <div className="flex items-center gap-2">
-                          <ListItemIcon className="min-w-0">
+                      <div className='flex flex-col ml-2'>
+                        <div className='flex items-center gap-2'>
+                          <ListItemIcon className='min-w-0'>
                             {plan.icon}
                           </ListItemIcon>
                           <div>
-                            <Typography variant="subtitle1" component="span" className="font-medium">
+                            <Typography
+                              variant='subtitle1'
+                              component='span'
+                              className='font-medium'
+                            >
                               {plan.name}
                             </Typography>
-                            <Typography variant="body2" color="text.secondary" className="block">
+                            <Typography
+                              variant='body2'
+                              color='text.secondary'
+                              className='block'
+                            >
                               {plan.description}
                             </Typography>
                           </div>
                         </div>
-                        <div className="mt-2">
-                          <Typography variant="subtitle2" color="primary" className="font-semibold mb-1">
+                        <div className='mt-2'>
+                          <Typography
+                            variant='subtitle2'
+                            color='primary'
+                            className='font-semibold mb-1'
+                          >
                             Cost: {plan.cost}
                           </Typography>
-                          <ul className="list-disc ml-4 text-sm text-gray-600">
+                          <ul className='list-disc ml-4 text-sm text-gray-600'>
                             {plan.features.map((feature, i) => (
                               <li key={i}>{feature}</li>
                             ))}
@@ -120,7 +149,7 @@ const ProtectionPlanSheet: React.FC<ProtectionPlanSheetProps> = ({
                         </div>
                       </div>
                     }
-                    className="m-0 w-full"
+                    className='m-0 w-full'
                   />
                 </ListItem>
                 {index < plans.length - 1 && <Divider />}

--- a/components/layout/PageHeader.tsx
+++ b/components/layout/PageHeader.tsx
@@ -1,0 +1,68 @@
+import { ChevronLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { motion } from 'framer-motion';
+import Image from 'next/image';
+
+interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  imageUrl?: string;
+  showBackButton?: boolean;
+  onBack?: () => void;
+  loanAmount?: number;
+  isSubmitting?: boolean;
+}
+
+export const PageHeader: React.FC<PageHeaderProps> = ({
+  title,
+  subtitle,
+  imageUrl,
+  showBackButton = true,
+  onBack,
+}) => {
+  const router = useRouter();
+
+  return (
+    <div className='bg-gradient-to-r from-[#A2195E] to-[#8B1550] p-4'>
+      <div className='flex items-center gap-3'>
+        {showBackButton && (
+          <button
+            onClick={onBack || (() => router.push('/'))}
+            className='text-white transition-opacity hover:opacity-80'
+          >
+            <ChevronLeft className='w-6 h-6' />
+          </button>
+        )}
+        <h1 className='text-xl font-semibold text-white'>{title}</h1>
+      </div>
+
+      {(subtitle || imageUrl) && (
+        <div className='px-4 mt-6 text-white'>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2 }}
+          >
+            <div className='flex items-center justify-between'>
+              <div>
+                <h2 className='mb-2 text-2xl font-bold'>{title}</h2>
+                {subtitle && <p className='text-white/80'>{subtitle}</p>}
+              </div>
+              {imageUrl && (
+                <div className='relative w-20 h-20'>
+                  <Image
+                    src={imageUrl}
+                    alt={title}
+                    width={80}
+                    height={80}
+                    className='brightness-0 invert opacity-90'
+                  />
+                </div>
+              )}
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/layout/SuccessLayout.tsx
+++ b/components/layout/SuccessLayout.tsx
@@ -1,0 +1,102 @@
+import { CheckCircleIcon } from '@heroicons/react/24/outline';
+import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import ReactConfetti from 'react-confetti';
+
+interface SuccessStep {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+interface SuccessLayoutProps {
+  title: string;
+  description: string;
+  steps: SuccessStep[];
+  actionText: string;
+  onActionClick: () => void;
+}
+
+export const SuccessLayout: React.FC<SuccessLayoutProps> = ({
+  title,
+  description,
+  steps,
+  actionText,
+  onActionClick,
+}) => {
+  const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    setWindowSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  }, []);
+
+  return (
+    <div className='flex-1 overflow-y-auto'>
+      <ReactConfetti
+        width={windowSize.width}
+        height={windowSize.height}
+        recycle={false}
+        numberOfPieces={200}
+        gravity={0.2}
+      />
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className='flex flex-col items-center justify-center min-h-full px-6 pt-10 pb-24'
+      >
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: 'spring', stiffness: 200, damping: 15 }}
+          className='flex items-center justify-center w-20 h-20 mb-6 bg-green-100 rounded-full'
+        >
+          <CheckCircleIcon className='w-12 h-12 text-green-600' />
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+          className='text-center'
+        >
+          <h2 className='mb-4 text-3xl font-bold text-gray-800'>{title}</h2>
+          <p className='max-w-md mb-8 text-lg text-gray-600'>{description}</p>
+        </motion.div>
+
+        <div className='grid w-full max-w-4xl grid-cols-1 gap-6 md:grid-cols-3'>
+          {steps.map((step, index) => (
+            <motion.div
+              key={index}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.4 + index * 0.1 }}
+              className='p-6 bg-white shadow-lg rounded-2xl'
+            >
+              <div className='flex items-center justify-center w-12 h-12 mb-4 bg-pink-100 rounded-full'>
+                <div className='text-pink-600'>{step.icon}</div>
+              </div>
+              <h3 className='mb-2 text-lg font-semibold text-gray-800'>
+                {step.title}
+              </h3>
+              <p className='text-gray-600'>{step.description}</p>
+            </motion.div>
+          ))}
+        </div>
+
+        <motion.button
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.8 }}
+          onClick={onActionClick}
+          className='px-8 py-3 mt-8 font-medium text-white transition-colors duration-300 bg-pink-600 rounded-full hover:bg-pink-700'
+        >
+          {actionText}
+        </motion.button>
+      </motion.div>
+    </div>
+  );
+};

--- a/components/report-borrower-app-bar.tsx
+++ b/components/report-borrower-app-bar.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { ChevronLeft } from 'lucide-react';
+import { motion } from 'framer-motion';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+export function ReportBorrowerAppBar() {
+  const router = useRouter();
+
+  return (
+    <div className='bg-gradient-to-r from-[#A2195E] to-[#8B1550] p-4'>
+      <div className='flex items-center gap-3'>
+        <button
+          onClick={() => router.push('/')}
+          className='text-white transition-opacity hover:opacity-80'
+        >
+          <ChevronLeft className='w-6 h-6' />
+        </button>
+        <h1 className='text-xl font-semibold text-white'>Report Borrower</h1>
+      </div>
+
+      <div className='px-4 mt-6 text-white'>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+        >
+          <div className='flex items-center justify-between'>
+            <div>
+              <h2 className='mb-2 text-2xl font-bold'>Report Unpaid Loan</h2>
+              <p className='text-white/80'>
+                Help us maintain a healthy credit ecosystem
+              </p>
+            </div>
+            <div className='relative w-20 h-20'>
+              <Image
+                src='/images/Frame.svg'
+                alt='Report Icon'
+                width={80}
+                height={80}
+                className='brightness-0 invert opacity-90'
+              />
+            </div>
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/components/shared/emi-calculator.tsx
+++ b/components/shared/emi-calculator.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Image from 'next/image';
+import { type LoanFormData } from '@/types/loan';
+
+interface EMICalculatorProps {
+  formData: LoanFormData;
+}
+
+export function EMICalculator({ formData }: EMICalculatorProps) {
+  const calculateEMI = () => {
+    if (!formData.loanAmount || !formData.interestRate || !formData.loanTerm)
+      return 0;
+
+    const principal = parseFloat(formData.loanAmount);
+    const ratePerPeriod =
+      parseFloat(formData.interestRate) /
+      100 /
+      (formData.emiFrequency === 'daily' ? 365 : 12);
+    let numberOfPayments: number;
+
+    if (formData.timeUnit === 'year') {
+      numberOfPayments =
+        formData.emiFrequency === 'daily'
+          ? 365 * parseFloat(formData.loanTerm)
+          : 12 * parseFloat(formData.loanTerm);
+    } else if (formData.timeUnit === 'month') {
+      numberOfPayments =
+        formData.emiFrequency === 'daily'
+          ? 30 * parseFloat(formData.loanTerm)
+          : parseFloat(formData.loanTerm);
+    } else {
+      numberOfPayments =
+        formData.emiFrequency === 'daily'
+          ? parseFloat(formData.loanTerm)
+          : parseFloat(formData.loanTerm) / 30;
+    }
+
+    const emi =
+      (principal *
+        ratePerPeriod *
+        Math.pow(1 + ratePerPeriod, numberOfPayments)) /
+      (Math.pow(1 + ratePerPeriod, numberOfPayments) - 1);
+
+    return isNaN(emi) ? 0 : emi;
+  };
+
+  const emiAmount = calculateEMI();
+
+  if (emiAmount <= 0) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className='p-6 text-white bg-gradient-to-r from-pink-600 to-purple-600 rounded-3xl'
+    >
+      <h3 className='mb-2 text-lg font-semibold'>EMI Calculator</h3>
+      <div className='flex items-center justify-between'>
+        <div>
+          <p className='text-sm opacity-90'>
+            {formData.type === 'give' ? 'Expected' : 'Estimated'} EMI Amount
+          </p>
+          <p className='text-2xl font-bold'>₹{emiAmount.toFixed(2)}</p>
+        </div>
+        <div className='flex items-center justify-center w-12 h-12 rounded-full bg-white/20'>
+          <Image
+            src='/images/calculator.svg'
+            alt='Calculator'
+            width={24}
+            height={24}
+          />
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/components/shared/emi-frequency-selector.tsx
+++ b/components/shared/emi-frequency-selector.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Select, MenuItem } from '@mui/material';
+
+interface EMIFrequencySelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function EMIFrequencySelector({
+  value,
+  onChange,
+}: EMIFrequencySelectorProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: 'auto' }}
+      exit={{ opacity: 0, height: 0 }}
+    >
+      <label className='block mb-2 text-sm font-medium text-gray-700'>
+        EMI Frequency
+      </label>
+      <Select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className='w-full rounded-xl'
+        sx={{
+          borderRadius: '12px',
+          '& .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#E5E5E5',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#A2195E',
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#A2195E',
+          },
+        }}
+      >
+        <MenuItem value='daily'>Daily</MenuItem>
+        <MenuItem value='weekly'>Weekly</MenuItem>
+        <MenuItem value='monthly'>Monthly</MenuItem>
+      </Select>
+    </motion.div>
+  );
+}

--- a/components/shared/info-modal.tsx
+++ b/components/shared/info-modal.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { AlertCircle, X } from 'lucide-react';
+import { Box, Button, IconButton, Modal, Typography } from '@mui/material';
+import { motion } from 'framer-motion';
+
+interface InfoModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+export function InfoModal({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+}: InfoModalProps) {
+  return (
+    <Modal open={open} onClose={onClose} aria-labelledby={title}>
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: '95%',
+          maxWidth: '600px',
+          bgcolor: 'background.paper',
+          borderRadius: '20px',
+          boxShadow:
+            '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
+          p: { xs: 3, sm: 4 },
+          maxHeight: { xs: '85vh', sm: '90vh' },
+          overflow: 'auto',
+          '&:focus': {
+            outline: 'none',
+          },
+        }}
+      >
+        <div className='flex items-center justify-between mb-4'>
+          <Typography
+            variant='h6'
+            component='h2'
+            sx={{
+              color: '#A2195E',
+              fontWeight: 600,
+              fontSize: { xs: '1.1rem', sm: '1.25rem' },
+            }}
+          >
+            {title}
+          </Typography>
+          <IconButton
+            onClick={onClose}
+            sx={{
+              color: 'gray',
+              '&:hover': { color: '#A2195E' },
+            }}
+          >
+            <X className='w-5 h-5' />
+          </IconButton>
+        </div>
+
+        {/* Important Notice */}
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className='p-3 mb-5 border border-orange-200 bg-orange-50 rounded-xl'
+        >
+          <div className='flex gap-2'>
+            <AlertCircle className='w-5 h-5 text-orange-500 flex-shrink-0 mt-0.5' />
+            <Typography
+              variant='body2'
+              sx={{
+                color: 'rgb(194,65,12)',
+                fontSize: { xs: '0.875rem', sm: '0.9375rem' },
+              }}
+            >
+              {description}
+            </Typography>
+          </div>
+        </motion.div>
+
+        <div className='space-y-4'>{children}</div>
+
+        <Button
+          onClick={onClose}
+          fullWidth
+          variant='contained'
+          sx={{
+            mt: 4,
+            height: { xs: '44px', sm: '48px' },
+            background: 'linear-gradient(to right, #A2195E, #8B1550)',
+            '&:hover': {
+              background: 'linear-gradient(to right, #8B1550, #A2195E)',
+            },
+            borderRadius: '12px',
+            textTransform: 'none',
+            fontSize: { xs: '0.9375rem', sm: '1rem' },
+            fontWeight: '600',
+          }}
+        >
+          Got it
+        </Button>
+      </Box>
+    </Modal>
+  );
+}

--- a/components/shared/loan-form.tsx
+++ b/components/shared/loan-form.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { StyledTextField } from './styled-text-field';
+import { Select, MenuItem } from '@mui/material';
+import { IndianRupee, Calendar } from 'lucide-react';
+import { PaymentTypeSelector } from './payment-type-selector';
+import { EMIFrequencySelector } from './emi-frequency-selector';
+import { EMICalculator } from './emi-calculator';
+import { type LoanFormData } from '@/types/loan';
+
+interface LoanFormProps {
+  formData: LoanFormData;
+  onChange: (data: Partial<LoanFormData>) => void;
+  onSubmit: () => void;
+  submitButtonText?: string;
+  showEMICalculator?: boolean;
+}
+
+export function LoanForm({
+  formData,
+  onChange,
+  onSubmit,
+  submitButtonText = 'Submit',
+  showEMICalculator = true,
+}: LoanFormProps) {
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className='space-y-6'>
+      <div className='p-6 bg-white shadow-lg rounded-3xl'>
+        <h2 className='mb-6 text-2xl font-bold text-gray-800'>Loan Details</h2>
+
+        <div className='space-y-6'>
+          {/* Amount Input */}
+          <div>
+            <label className='block mb-2 text-sm font-medium text-gray-700'>
+              {formData.type === 'give' ? 'Amount to Lend' : 'Loan Amount'}
+            </label>
+            <div className='relative'>
+              <IndianRupee className='absolute w-5 h-5 text-gray-400 -translate-y-1/2 left-3 top-1/2' />
+              <StyledTextField
+                fullWidth
+                type='number'
+                value={formData.loanAmount}
+                onChange={(e) => onChange({ loanAmount: e.target.value })}
+                placeholder='Enter amount'
+                InputProps={{
+                  startAdornment: <span className='mr-2 text-gray-500'>₹</span>,
+                }}
+                className='mb-1'
+              />
+            </div>
+            <p className='mt-1 text-sm text-gray-500'>
+              Min: ₹1,000 | Max: ₹10,00,000
+            </p>
+          </div>
+
+          {/* Term and Unit Inputs */}
+          <div className='grid grid-cols-2 gap-4'>
+            <div>
+              <label className='block mb-2 text-sm font-medium text-gray-700'>
+                {formData.type === 'give' ? 'Lending Term' : 'Loan Term'}
+              </label>
+              <StyledTextField
+                fullWidth
+                type='number'
+                value={formData.loanTerm}
+                onChange={(e) => onChange({ loanTerm: e.target.value })}
+                placeholder='Duration'
+              />
+            </div>
+            <div>
+              <label className='block mb-2 text-sm font-medium text-gray-700'>
+                Time Unit
+              </label>
+              <Select
+                value={formData.timeUnit}
+                onChange={(e) => onChange({ timeUnit: e.target.value })}
+                className='w-full rounded-xl'
+                sx={{
+                  borderRadius: '12px',
+                  '& .MuiOutlinedInput-notchedOutline': {
+                    borderColor: '#E5E5E5',
+                  },
+                  '&:hover .MuiOutlinedInput-notchedOutline': {
+                    borderColor: '#A2195E',
+                  },
+                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                    borderColor: '#A2195E',
+                  },
+                }}
+              >
+                <MenuItem value='month'>Months</MenuItem>
+                <MenuItem value='year'>Years</MenuItem>
+                <MenuItem value='day'>Days</MenuItem>
+              </Select>
+            </div>
+          </div>
+
+          {/* Interest Rate Input */}
+          <div>
+            <label className='block mb-2 text-sm font-medium text-gray-700'>
+              {formData.type === 'give'
+                ? 'Expected Interest Rate'
+                : 'Interest Rate'}{' '}
+              (% per annum)
+            </label>
+            <StyledTextField
+              fullWidth
+              type='number'
+              value={formData.interestRate}
+              onChange={(e) => onChange({ interestRate: e.target.value })}
+              placeholder='Enter interest rate'
+              InputProps={{
+                endAdornment: <span className='text-gray-500'>%</span>,
+              }}
+            />
+          </div>
+
+          {/* Payment Type Selection */}
+          <PaymentTypeSelector
+            value={formData.paymentType}
+            onChange={(value) => onChange({ paymentType: value })}
+          />
+
+          {/* EMI Frequency Selection */}
+          {formData.paymentType === 'emi' && (
+            <EMIFrequencySelector
+              value={formData.emiFrequency}
+              onChange={(value) => onChange({ emiFrequency: value })}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* EMI Calculator */}
+      {showEMICalculator && formData.paymentType === 'emi' && (
+        <EMICalculator formData={formData} />
+      )}
+
+      {/* Submit Button */}
+      <motion.button
+        type='submit'
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        className='w-full py-4 font-semibold text-white transition-colors bg-pink-600 rounded-xl hover:bg-pink-700'
+      >
+        {submitButtonText}
+      </motion.button>
+    </form>
+  );
+}

--- a/components/shared/payment-type-selector.tsx
+++ b/components/shared/payment-type-selector.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Radio, RadioGroup, FormControlLabel } from '@mui/material';
+import Image from 'next/image';
+
+interface PaymentTypeSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function PaymentTypeSelector({
+  value,
+  onChange,
+}: PaymentTypeSelectorProps) {
+  return (
+    <div>
+      <label className='block mb-4 text-sm font-medium text-gray-700'>
+        Payment Type
+      </label>
+      <div className='grid grid-cols-2 gap-4'>
+        <motion.div whileTap={{ scale: 0.98 }}>
+          <FormControlLabel
+            value='onetime'
+            control={
+              <Radio
+                checked={value === 'onetime'}
+                onChange={(e) => onChange(e.target.value)}
+              />
+            }
+            label={
+              <div
+                className={`flex flex-col items-center p-4 rounded-xl cursor-pointer transition-all
+                ${value === 'onetime' ? 'bg-pink-50' : 'bg-gray-50 hover:bg-gray-100'}`}
+              >
+                <Image
+                  src='/images/onetime-payment.svg'
+                  alt='One-time Payment'
+                  width={32}
+                  height={32}
+                  className='mb-2'
+                />
+                <span className='text-sm font-medium text-gray-800'>
+                  One-time Payment
+                </span>
+              </div>
+            }
+            className='w-full m-0'
+          />
+        </motion.div>
+
+        <motion.div whileTap={{ scale: 0.98 }}>
+          <FormControlLabel
+            value='emi'
+            control={
+              <Radio
+                checked={value === 'emi'}
+                onChange={(e) => onChange(e.target.value)}
+              />
+            }
+            label={
+              <div
+                className={`flex flex-col items-center p-4 rounded-xl cursor-pointer transition-all
+                ${value === 'emi' ? 'bg-pink-50' : 'bg-gray-50 hover:bg-gray-100'}`}
+              >
+                <Image
+                  src='/images/emi-payment.svg'
+                  alt='EMI'
+                  width={32}
+                  height={32}
+                  className='mb-2'
+                />
+                <span className='text-sm font-medium text-gray-800'>EMI</span>
+              </div>
+            }
+            className='w-full m-0'
+          />
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/components/shared/profile-card.tsx
+++ b/components/shared/profile-card.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Image from 'next/image';
+import { type Profile } from '@/types/loan';
+
+interface ProfileCardProps {
+  profile: Profile;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+export function ProfileCard({
+  profile,
+  isSelected,
+  onClick,
+}: ProfileCardProps) {
+  return (
+    <motion.div
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      onClick={onClick}
+      className={`p-4 rounded-xl border-2 transition-all cursor-pointer ${
+        isSelected
+          ? 'border-pink-500 bg-pink-50'
+          : 'border-gray-200 hover:border-pink-200'
+      }`}
+    >
+      <div className='flex items-center space-x-4'>
+        <div className='w-12 h-12 overflow-hidden bg-gray-100 rounded-full'>
+          <Image
+            src={profile.image}
+            alt={profile.name}
+            width={48}
+            height={48}
+            className='object-cover'
+          />
+        </div>
+        <div>
+          <h3 className='font-semibold text-gray-800'>{profile.name}</h3>
+          <p className='text-sm text-gray-500'>{profile.mobile}</p>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/components/shared/profile-selector.tsx
+++ b/components/shared/profile-selector.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Radio, RadioGroup, FormControlLabel } from '@mui/material';
+import Image from 'next/image';
+import { StyledTextField } from './styled-text-field';
+import {
+  CheckCircleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/24/outline';
+import { Profile } from '@/types/loan';
+import { ProfileCard } from './profile-card';
+import { WarningMessage } from './warning-message';
+
+interface ProfileSelectorProps {
+  type: 'borrower' | 'lender';
+  savedProfiles: Profile[];
+  onProfileSelect: (profile: Profile | null) => void;
+  onMobileNumberSubmit: (mobile: string) => void;
+}
+
+export function ProfileSelector({
+  type,
+  savedProfiles,
+  onProfileSelect,
+  onMobileNumberSubmit,
+}: ProfileSelectorProps) {
+  const [requestType, setRequestType] = useState('saved');
+  const [mobileNumber, setMobileNumber] = useState('');
+  const [selectedProfile, setSelectedProfile] = useState<Profile | null>(null);
+  const [warningMessage, setWarningMessage] = useState<string | null>(null);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const handleRequestTypeChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setRequestType(event.target.value);
+    setSelectedProfile(null);
+    setMobileNumber('');
+    onProfileSelect(null);
+  };
+
+  const handleProfileSelect = (profile: Profile) => {
+    setSelectedProfile(profile);
+    onProfileSelect(profile);
+  };
+
+  const handleMobileNumberChange = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const cleanNumber = e.target.value.replace(/[^\d]/g, '').slice(0, 10);
+    setMobileNumber(cleanNumber);
+    setWarningMessage(null);
+    setIsSuccess(false);
+
+    if (cleanNumber.length === 10) {
+      onMobileNumberSubmit(cleanNumber);
+    }
+  };
+
+  return (
+    <div className='p-6 mb-6 bg-white shadow-lg rounded-3xl'>
+      <h2 className='mb-6 text-2xl font-bold text-center text-gray-800'>
+        {type === 'borrower' ? 'Select Borrower' : 'Select Lender'}
+      </h2>
+
+      <RadioGroup
+        value={requestType}
+        onChange={handleRequestTypeChange}
+        className='mb-6'
+      >
+        <div className='grid grid-cols-2 gap-4'>
+          <motion.div whileTap={{ scale: 0.98 }}>
+            <FormControlLabel
+              value='saved'
+              control={<Radio />}
+              label={
+                <div className='flex flex-col items-center p-4 bg-pink-50 rounded-xl cursor-pointer transition-all hover:bg-pink-100 min-h-[120px] w-full justify-center'>
+                  <div className='flex items-center justify-center flex-shrink-0 w-12 h-12 bg-pink-200 rounded-full'>
+                    <Image
+                      src={
+                        type === 'borrower'
+                          ? '/images/savedborrowers.svg'
+                          : '/images/savedlenders.svg'
+                      }
+                      alt='Saved Profiles'
+                      width={32}
+                      height={32}
+                      className='mt-2 mb-2'
+                    />
+                  </div>
+                  <span className='font-medium text-gray-800'>
+                    Saved {type === 'borrower' ? 'Borrowers' : 'Lenders'}
+                  </span>
+                </div>
+              }
+              className='w-full m-0'
+            />
+          </motion.div>
+
+          <motion.div whileTap={{ scale: 0.98 }}>
+            <FormControlLabel
+              value='new'
+              control={<Radio />}
+              label={
+                <div className='flex flex-col items-center p-4 bg-pink-50 rounded-xl cursor-pointer transition-all hover:bg-pink-100 min-h-[120px] w-full justify-center'>
+                  <div className='flex items-center justify-center flex-shrink-0 w-12 h-12 bg-pink-200 rounded-full'>
+                    <Image
+                      src='/images/newprofile.svg'
+                      alt='New Profile'
+                      width={32}
+                      height={32}
+                      className='mt-1 mb-2'
+                    />
+                  </div>
+                  <span className='font-medium text-gray-800'>
+                    New {type === 'borrower' ? 'Borrower' : 'Lender'}
+                  </span>
+                </div>
+              }
+              className='w-full m-0'
+            />
+          </motion.div>
+        </div>
+      </RadioGroup>
+
+      <AnimatePresence mode='wait'>
+        {requestType === 'saved' ? (
+          <motion.div
+            key='saved'
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+          >
+            <div className='space-y-4'>
+              {savedProfiles.map((profile) => (
+                <ProfileCard
+                  key={profile.id}
+                  profile={profile}
+                  isSelected={selectedProfile?.id === profile.id}
+                  onClick={() => handleProfileSelect(profile)}
+                />
+              ))}
+            </div>
+          </motion.div>
+        ) : (
+          <motion.div
+            key='new'
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+          >
+            <StyledTextField
+              fullWidth
+              label='Mobile Number'
+              variant='outlined'
+              value={mobileNumber}
+              onChange={handleMobileNumberChange}
+              placeholder='Enter 10-digit number'
+              inputProps={{
+                maxLength: 10,
+                pattern: '[0-9]*',
+              }}
+              className='mb-4'
+            />
+            {warningMessage && (
+              <WarningMessage message={warningMessage} isSuccess={isSuccess} />
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/shared/recovery-modal-content.tsx
+++ b/components/shared/recovery-modal-content.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Typography } from '@mui/material';
+
+export function RecoveryModalContent() {
+  const steps = [
+    {
+      step: 1,
+      title: 'Initial Verification',
+      description:
+        'To prevent fraudulent reports, we first verify with the borrower about receiving the loan. Their acknowledgment serves as proof for proceeding with recovery. This step protects both genuine lenders and borrowers.',
+    },
+    {
+      step: 2,
+      title: 'Documentation Review',
+      description:
+        "If you have any proof of lending (WhatsApp messages, UPI transactions, written notes, etc.), you can provide them to strengthen the recovery case. However, this is optional and we'll proceed even without formal documentation.",
+    },
+    {
+      step: 3,
+      title: 'Professional Communication',
+      description:
+        'Once verified, our recovery experts initiate professional communication with the borrower through calls and messages. We maintain a respectful approach while representing you.',
+    },
+    {
+      step: 4,
+      title: 'Resolution & Recovery',
+      description:
+        'We work to establish a repayment plan and facilitate the recovery of your funds through a structured and professional approach.',
+    },
+    {
+      step: 5,
+      title: 'Progress Updates',
+      description:
+        "You'll receive regular updates about the recovery progress through our platform, keeping you informed at every step of the process.",
+    },
+  ];
+
+  return (
+    <div className='relative'>
+      <div className='absolute left-4 top-4 bottom-4 w-0.5 bg-pink-100'></div>
+      <div className='space-y-6'>
+        {steps.map(({ step, title, description }) => (
+          <div key={step} className='flex gap-3'>
+            <div className='relative z-10 flex items-center justify-center flex-shrink-0 w-8 h-8 bg-pink-100 rounded-full'>
+              <span className='text-[#A2195E] font-semibold'>{step}</span>
+            </div>
+            <div className='flex-1'>
+              <Typography
+                variant='subtitle1'
+                sx={{
+                  fontWeight: 600,
+                  mb: 0.5,
+                  fontSize: { xs: '0.9375rem', sm: '1rem' },
+                }}
+              >
+                {title}
+              </Typography>
+              <Typography
+                variant='body2'
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: { xs: '0.875rem', sm: '0.9375rem' },
+                }}
+              >
+                {description}
+              </Typography>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/shared/report-form.tsx
+++ b/components/shared/report-form.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import {
+  TextField,
+  FormControlLabel,
+  Checkbox,
+  Typography,
+  Button,
+} from '@mui/material';
+import { Phone, Calendar, IndianRupee, AlertCircle } from 'lucide-react';
+import { type LoanFormData } from '@/types/loan';
+
+interface ReportFormProps {
+  formData: LoanFormData;
+  warningMessage: string | null;
+  onSubmit: (e: React.FormEvent) => void;
+  onChange: (field: string, value: string | boolean) => void;
+}
+
+export function ReportForm({
+  formData,
+  warningMessage,
+  onSubmit,
+  onChange,
+}: ReportFormProps) {
+  return (
+    <form onSubmit={onSubmit} className='mt-4 space-y-6'>
+      {/* Phone Input */}
+      <div className='relative'>
+        <Phone className='absolute w-5 h-5 text-gray-400 -translate-y-1/2 left-3 top-1/2' />
+        <TextField
+          fullWidth
+          label="Borrower's Phone Number"
+          variant='outlined'
+          value={formData.borrowerPhone}
+          onChange={(e) => onChange('borrowerPhone', e.target.value)}
+          type='tel'
+          required
+          inputProps={{
+            pattern: '[0-9]{10}',
+            maxLength: 10,
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              paddingLeft: '2.5rem',
+              borderRadius: '12px',
+              '&:hover fieldset': {
+                borderColor: '#A2195E',
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: '#A2195E',
+              },
+            },
+            '& .MuiInputLabel-root': {
+              transform: 'translate(2.5rem, 1rem) scale(1)',
+            },
+            '& .MuiInputLabel-root.Mui-focused, & .MuiInputLabel-root.MuiFormLabel-filled':
+              {
+                transform: 'translate(1rem, -0.5rem) scale(0.75)',
+              },
+            '& .MuiInputLabel-root.Mui-focused': {
+              color: '#A2195E',
+            },
+          }}
+        />
+      </div>
+
+      {warningMessage && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className='flex items-center p-4 border border-orange-200 rounded-lg bg-orange-50'
+        >
+          <AlertCircle className='flex-shrink-0 w-5 h-5 mr-2 text-orange-500' />
+          <Typography className='text-orange-700'>{warningMessage}</Typography>
+        </motion.div>
+      )}
+
+      {/* Amount Input */}
+      <div className='relative'>
+        <IndianRupee className='absolute w-5 h-5 text-gray-400 -translate-y-1/2 left-3 top-1/2' />
+        <TextField
+          fullWidth
+          label='Unpaid Amount'
+          variant='outlined'
+          value={formData.loanAmount}
+          onChange={(e) => onChange('loanAmount', e.target.value)}
+          type='number'
+          required
+          inputProps={{
+            min: 0,
+            step: '0.01',
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              paddingLeft: '2.5rem',
+              borderRadius: '12px',
+              '&:hover fieldset': {
+                borderColor: '#A2195E',
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: '#A2195E',
+              },
+            },
+            '& .MuiInputLabel-root': {
+              transform: 'translate(2.5rem, 1rem) scale(1)',
+            },
+            '& .MuiInputLabel-root.Mui-focused, & .MuiInputLabel-root.MuiFormLabel-filled':
+              {
+                transform: 'translate(1rem, -0.5rem) scale(0.75)',
+              },
+            '& .MuiInputLabel-root.Mui-focused': {
+              color: '#A2195E',
+            },
+          }}
+        />
+      </div>
+
+      {/* Date Input */}
+      <div className='relative'>
+        <Calendar className='absolute w-5 h-5 text-gray-400 -translate-y-1/2 left-3 top-1/2' />
+        <TextField
+          fullWidth
+          label='Due Date'
+          type='date'
+          variant='outlined'
+          value={formData.dueDate}
+          onChange={(e) => onChange('dueDate', e.target.value)}
+          required
+          inputProps={{
+            max: new Date().toISOString().split('T')[0],
+          }}
+          InputLabelProps={{
+            shrink: true,
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              paddingLeft: '2.5rem',
+              borderRadius: '12px',
+              '&:hover fieldset': {
+                borderColor: '#A2195E',
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: '#A2195E',
+              },
+            },
+            '& .MuiInputLabel-root.Mui-focused': {
+              color: '#A2195E',
+            },
+          }}
+        />
+      </div>
+
+      {/* Consent Section */}
+      <div className='p-4 border border-gray-100 bg-gray-50 rounded-xl'>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={formData.consent}
+              onChange={(e) => onChange('consent', e.target.checked)}
+              required
+              sx={{
+                color: '#A2195E',
+                '&.Mui-checked': {
+                  color: '#A2195E',
+                },
+              }}
+            />
+          }
+          label={
+            <Typography variant='body2' className='text-gray-700'>
+              {formData.reportType === 'recovery_service'
+                ? 'I hereby give consent to make recovery calls on my behalf and agree to the recovery process'
+                : 'I hereby confirm that the information provided is accurate and can be used to warn other lenders'}
+            </Typography>
+          }
+        />
+      </div>
+
+      {/* Submit Button */}
+      <motion.div whileTap={{ scale: 0.98 }} className='pt-4'>
+        <Button
+          type='submit'
+          variant='contained'
+          fullWidth
+          size='large'
+          disabled={!formData.consent || !warningMessage}
+          sx={{
+            height: '56px',
+            background: 'linear-gradient(to right, #A2195E, #8B1550)',
+            '&:hover': {
+              background: 'linear-gradient(to right, #8B1550, #A2195E)',
+            },
+            '&:disabled': {
+              background: '#e0e0e0',
+              opacity: 0.7,
+              cursor: 'not-allowed',
+            },
+            borderRadius: '14px',
+            textTransform: 'none',
+            fontSize: '1.1rem',
+            fontWeight: '600',
+            boxShadow:
+              '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+          }}
+        >
+          {formData.reportType === 'recovery_service'
+            ? 'Submit Report & Start Recovery'
+            : 'Submit Report'}
+        </Button>
+      </motion.div>
+    </form>
+  );
+}

--- a/components/shared/report-modal-content.tsx
+++ b/components/shared/report-modal-content.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { Shield, AlertCircle, PhoneCall, Users } from 'lucide-react';
+import { Typography } from '@mui/material';
+
+export function ReportModalContent() {
+  return (
+    <div className='relative'>
+      <div className='absolute left-4 top-4 bottom-4 w-0.5 bg-pink-100'></div>
+      <div className='space-y-6'>
+        <div className='flex gap-3'>
+          <div className='relative z-10 flex items-center justify-center flex-shrink-0 w-8 h-8 bg-pink-100 rounded-full'>
+            <Shield className='w-4 h-4 text-[#A2195E]' />
+          </div>
+          <div className='flex-1'>
+            <Typography
+              variant='subtitle1'
+              sx={{
+                fontWeight: 600,
+                mb: 0.5,
+                fontSize: { xs: '0.9375rem', sm: '1rem' },
+              }}
+            >
+              Protect the Community
+            </Typography>
+            <Typography
+              variant='body2'
+              sx={{
+                color: 'text.secondary',
+                fontSize: { xs: '0.875rem', sm: '0.9375rem' },
+              }}
+            >
+              Your report helps other lenders make informed decisions before
+              lending money. This creates a safer lending environment for
+              everyone.
+            </Typography>
+          </div>
+        </div>
+
+        <div className='flex gap-3'>
+          <div className='relative z-10 flex items-center justify-center flex-shrink-0 w-8 h-8 bg-pink-100 rounded-full'>
+            <AlertCircle className='w-4 h-4 text-[#A2195E]' />
+          </div>
+          <div className='flex-1'>
+            <Typography
+              variant='subtitle1'
+              sx={{
+                fontWeight: 600,
+                mb: 0.5,
+                fontSize: { xs: '0.9375rem', sm: '1rem' },
+              }}
+            >
+              Early Warning System
+            </Typography>
+            <Typography
+              variant='body2'
+              sx={{
+                color: 'text.secondary',
+                fontSize: { xs: '0.875rem', sm: '0.9375rem' },
+              }}
+            >
+              When someone checks a borrower's history, they'll see your report
+              as a warning sign, helping them avoid potential defaults.
+            </Typography>
+          </div>
+        </div>
+
+        <div className='flex gap-3'>
+          <div className='relative z-10 flex items-center justify-center flex-shrink-0 w-8 h-8 bg-pink-100 rounded-full'>
+            <PhoneCall className='w-4 h-4 text-[#A2195E]' />
+          </div>
+          <div className='flex-1'>
+            <Typography
+              variant='subtitle1'
+              sx={{
+                fontWeight: 600,
+                mb: 0.5,
+                fontSize: { xs: '0.9375rem', sm: '1rem' },
+              }}
+            >
+              Future Recovery Options
+            </Typography>
+            <Typography
+              variant='body2'
+              sx={{
+                color: 'text.secondary',
+                fontSize: { xs: '0.875rem', sm: '0.9375rem' },
+              }}
+            >
+              Even if you choose to only report now, you can always opt for our
+              recovery service later if needed.
+            </Typography>
+          </div>
+        </div>
+
+        <div className='flex gap-3'>
+          <div className='relative z-10 flex items-center justify-center flex-shrink-0 w-8 h-8 bg-pink-100 rounded-full'>
+            <Users className='w-4 h-4 text-[#A2195E]' />
+          </div>
+          <div className='flex-1'>
+            <Typography
+              variant='subtitle1'
+              sx={{
+                fontWeight: 600,
+                mb: 0.5,
+                fontSize: { xs: '0.9375rem', sm: '1rem' },
+              }}
+            >
+              Build Trust
+            </Typography>
+            <Typography
+              variant='body2'
+              sx={{
+                color: 'text.secondary',
+                fontSize: { xs: '0.875rem', sm: '0.9375rem' },
+              }}
+            >
+              Your report contributes to building a trusted lending community.
+              Together, we can make informal lending safer for everyone.
+            </Typography>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/shared/report-type-selector.tsx
+++ b/components/shared/report-type-selector.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Radio, RadioGroup, FormControlLabel, IconButton } from '@mui/material';
+import { Shield, PhoneCall, Info } from 'lucide-react';
+
+interface ReportTypeSelectorProps {
+  value: 'report_only' | 'recovery_service';
+
+  onChange: (value: 'report_only' | 'recovery_service') => void;
+
+  onInfoClick: (type: 'report_only' | 'recovery_service') => void;
+}
+
+export function ReportTypeSelector({
+  value,
+  onChange,
+  onInfoClick,
+}: ReportTypeSelectorProps) {
+  return (
+    <div className='space-y-4'>
+      <h3 className='font-semibold text-gray-700'>Choose Report Type</h3>
+      <RadioGroup
+        value={value}
+        onChange={(e) =>
+          onChange(e.target.value as 'report_only' | 'recovery_service')
+        }
+        className='space-y-3'
+      >
+        <motion.div
+          whileHover={{ scale: 1.01 }}
+          whileTap={{ scale: 0.99 }}
+          className={`relative rounded-xl border-2 transition-all cursor-pointer
+            ${
+              value === 'report_only'
+                ? 'border-[#A2195E] bg-pink-50'
+                : 'border-gray-200 bg-white'
+            }`}
+        >
+          <FormControlLabel
+            value='report_only'
+            control={
+              <Radio
+                sx={{
+                  color: '#A2195E',
+                  '&.Mui-checked': {
+                    color: '#A2195E',
+                  },
+                }}
+              />
+            }
+            label={
+              <div className='py-2'>
+                <div className='flex items-center gap-3'>
+                  <Shield className='w-5 h-5 text-[#A2195E]' />
+                  <span className='font-semibold text-gray-800'>
+                    Report Only
+                  </span>
+                  <IconButton
+                    onClick={(e) => {
+                      e.preventDefault();
+                      onInfoClick('report_only');
+                    }}
+                    size='small'
+                    sx={{ color: '#A2195E' }}
+                  >
+                    <Info className='w-4 h-4' />
+                  </IconButton>
+                </div>
+                <p className='mt-1 ml-8 text-sm text-gray-600'>
+                  Report defaulter to protect others. This information will be
+                  used to warn other lenders.
+                </p>
+                <div className='ml-8 mt-2 text-sm font-medium text-[#A2195E]'>
+                  Free
+                </div>
+              </div>
+            }
+            className='w-full p-3 m-0'
+          />
+        </motion.div>
+
+        <motion.div
+          whileHover={{ scale: 1.01 }}
+          whileTap={{ scale: 0.99 }}
+          className={`relative rounded-xl border-2 transition-all cursor-pointer
+            ${
+              value === 'recovery_service'
+                ? 'border-[#A2195E] bg-pink-50'
+                : 'border-gray-200 bg-white'
+            }`}
+        >
+          <FormControlLabel
+            value='recovery_service'
+            control={
+              <Radio
+                sx={{
+                  color: '#A2195E',
+                  '&.Mui-checked': {
+                    color: '#A2195E',
+                  },
+                }}
+              />
+            }
+            label={
+              <div className='py-2'>
+                <div className='flex items-center gap-3'>
+                  <PhoneCall className='w-5 h-5 text-[#A2195E]' />
+                  <span className='font-semibold text-gray-800'>
+                    Assistance Service
+                  </span>
+                  <IconButton
+                    onClick={(e) => {
+                      e.preventDefault();
+                      onInfoClick('recovery_service');
+                    }}
+                    size='small'
+                    sx={{ color: '#A2195E' }}
+                  >
+                    <Info className='w-4 h-4' />
+                  </IconButton>
+                </div>
+                <p className='mt-1 ml-8 text-sm text-gray-600'>
+                  We are here to assist you with recovering your money through
+                  our dedicated and professional recovery services.
+                </p>
+              </div>
+            }
+            className='w-full p-3 m-0'
+          />
+        </motion.div>
+      </RadioGroup>
+    </div>
+  );
+}

--- a/components/shared/styled-text-field.tsx
+++ b/components/shared/styled-text-field.tsx
@@ -1,0 +1,24 @@
+import { styled } from '@mui/material/styles';
+import { TextField } from '@mui/material';
+
+export const StyledTextField = styled(TextField)({
+  '& .MuiOutlinedInput-root': {
+    borderRadius: '12px',
+    backgroundColor: '#F9F9F9',
+    '& fieldset': {
+      borderColor: '#E5E5E5',
+    },
+    '&:hover fieldset': {
+      borderColor: '#A2195E',
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: '#A2195E',
+    },
+  },
+  '& .MuiInputLabel-root': {
+    color: '#666666',
+    '&.Mui-focused': {
+      color: '#A2195E',
+    },
+  },
+});

--- a/components/shared/success-state.tsx
+++ b/components/shared/success-state.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import {
+  CheckCircleIcon,
+  ChartBarIcon,
+  ClockIcon,
+  UserGroupIcon,
+} from '@heroicons/react/24/outline';
+import ReactConfetti from 'react-confetti';
+import { useWindowSize } from '@/hooks/use-window-size';
+
+interface SuccessStateProps {
+  title: string;
+  description: string;
+  steps: Array<{
+    icon: React.ReactNode;
+    title: string;
+    description: string;
+  }>;
+  onDashboardClick: () => void;
+}
+
+export function SuccessState({
+  title,
+  description,
+  steps,
+  onDashboardClick,
+}: SuccessStateProps) {
+  const { width, height } = useWindowSize();
+
+  return (
+    <div className='flex flex-col items-center justify-center min-h-full px-6 pt-10 pb-24'>
+      <ReactConfetti
+        width={width}
+        height={height}
+        recycle={false}
+        numberOfPieces={200}
+        gravity={0.2}
+      />
+
+      <motion.div
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ type: 'spring', stiffness: 200, damping: 15 }}
+        className='flex items-center justify-center w-20 h-20 mb-6 bg-green-100 rounded-full'
+      >
+        <CheckCircleIcon className='w-12 h-12 text-green-600' />
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2 }}
+        className='text-center'
+      >
+        <h2 className='mb-4 text-3xl font-bold text-gray-800'>{title}</h2>
+        <p className='max-w-md mb-8 text-lg text-gray-600'>{description}</p>
+      </motion.div>
+
+      <div className='grid w-full max-w-4xl grid-cols-1 gap-6 md:grid-cols-3'>
+        {steps.map((step, index) => (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.4 + index * 0.1 }}
+            className='p-6 transition-shadow duration-300 bg-white shadow-lg rounded-2xl hover:shadow-xl'
+          >
+            <div className='flex items-center justify-center w-12 h-12 mb-4 bg-pink-100 rounded-full'>
+              <div className='text-pink-600'>{step.icon}</div>
+            </div>
+            <h3 className='mb-2 text-lg font-semibold text-gray-800'>
+              {step.title}
+            </h3>
+            <p className='text-gray-600'>{step.description}</p>
+          </motion.div>
+        ))}
+      </div>
+
+      <motion.button
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.8 }}
+        onClick={onDashboardClick}
+        className='px-8 py-3 mt-8 font-medium text-white transition-colors duration-300 bg-pink-600 rounded-full hover:bg-pink-700'
+      >
+        Go to Dashboard
+      </motion.button>
+    </div>
+  );
+}

--- a/components/shared/warning-message.tsx
+++ b/components/shared/warning-message.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import {
+  CheckCircleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/24/outline';
+
+interface WarningMessageProps {
+  message: string;
+  isSuccess?: boolean;
+}
+
+export function WarningMessage({
+  message,
+  isSuccess = false,
+}: WarningMessageProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={`flex items-center p-4 mb-4 rounded-lg ${
+        isSuccess
+          ? 'bg-green-50 text-green-800'
+          : 'bg-yellow-50 text-yellow-800'
+      }`}
+    >
+      {isSuccess ? (
+        <CheckCircleIcon className='w-5 h-5 mr-2 text-green-600' />
+      ) : (
+        <InformationCircleIcon className='w-5 h-5 mr-2 text-yellow-600' />
+      )}
+      <span className='text-sm'>{message}</span>
+    </motion.div>
+  );
+}

--- a/hooks/use-loan-form.ts
+++ b/hooks/use-loan-form.ts
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { type LoanFormData } from '@/types/loan';
+
+const defaultFormData: LoanFormData = {
+  type: 'request',
+  loanAmount: '',
+  loanTerm: '',
+  timeUnit: 'month',
+  interestRate: '',
+  paymentType: 'onetime',
+  emiFrequency: 'monthly',
+  // Default values for report type
+  borrowerPhone: '',
+  dueDate: '',
+  consent: false,
+  reportType: 'report_only',
+};
+
+export function useLoanForm(type: LoanFormData['type'] = 'request') {
+  const [formData, setFormData] = useState<LoanFormData>({
+    ...defaultFormData,
+    type,
+  });
+
+  const updateFormData = (data: Partial<LoanFormData>) => {
+    setFormData((prev) => ({ ...prev, ...data }));
+  };
+
+  const calculateEMI = () => {
+    if (!formData.loanAmount || !formData.interestRate || !formData.loanTerm)
+      return 0;
+
+    const principal = parseFloat(formData.loanAmount);
+    const ratePerPeriod =
+      parseFloat(formData.interestRate) /
+      100 /
+      (formData.emiFrequency === 'daily' ? 365 : 12);
+    let numberOfPayments: number;
+
+    if (formData.timeUnit === 'year') {
+      numberOfPayments =
+        formData.emiFrequency === 'daily'
+          ? 365 * parseFloat(formData.loanTerm)
+          : 12 * parseFloat(formData.loanTerm);
+    } else if (formData.timeUnit === 'month') {
+      numberOfPayments =
+        formData.emiFrequency === 'daily'
+          ? 30 * parseFloat(formData.loanTerm)
+          : parseFloat(formData.loanTerm);
+    } else {
+      numberOfPayments =
+        formData.emiFrequency === 'daily'
+          ? parseFloat(formData.loanTerm)
+          : parseFloat(formData.loanTerm) / 30;
+    }
+
+    const emi =
+      (principal *
+        ratePerPeriod *
+        Math.pow(1 + ratePerPeriod, numberOfPayments)) /
+      (Math.pow(1 + ratePerPeriod, numberOfPayments) - 1);
+
+    return isNaN(emi) ? 0 : emi;
+  };
+
+  return {
+    formData,
+    updateFormData,
+    calculateEMI,
+  };
+}

--- a/hooks/use-window-size.ts
+++ b/hooks/use-window-size.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+interface WindowSize {
+  width: number;
+  height: number;
+}
+
+export function useWindowSize(): WindowSize {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: typeof window !== 'undefined' ? window.innerWidth : 0,
+    height: typeof window !== 'undefined' ? window.innerHeight : 0,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
+}

--- a/types/loan.ts
+++ b/types/loan.ts
@@ -1,0 +1,21 @@
+export interface LoanFormData {
+  type: 'give' | 'request' | 'report';
+  loanAmount: string;
+  loanTerm: string;
+  timeUnit: 'day' | 'month' | 'year';
+  interestRate: string;
+  paymentType: 'onetime' | 'emi';
+  emiFrequency?: 'daily' | 'weekly' | 'monthly';
+  // Additional fields for report type
+  borrowerPhone?: string;
+  dueDate?: string;
+  consent?: boolean;
+  reportType?: 'report_only' | 'recovery_service';
+}
+
+export interface Profile {
+  id: string;
+  name: string;
+  mobile: string;
+  image: string;
+}


### PR DESCRIPTION
# KYC Verification Gates for Free Plan Users

## Changes
- Added KYC dialog gates for the following actions when performed by free plan users:
  - Borrower report submission (/report-borrower)
  - Credit request submission (/request)
  - Credit offer submission (/give-credit)
- Updated KYC dialog redirect path to correctly route to user-specific profile pages (/profile/[uid])
- Refactored each page for improved readability and maintainability:
  - Enhanced type definitions
  - Improved route handling
  - Better component organization

## Testing
- [x] Verify KYC dialog appears for free plan users when:
  - Submitting a borrower report
  - Submitting a credit request
  - Submitting a credit offer
- [x] Confirm "Start KYC Process" button redirects to the correct user profile page
- [x] Verify "Maybe Later" button closes the dialog correctly